### PR TITLE
Employing user-defined API keys for RetroAchievements

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1619,9 +1619,9 @@ bool ApiSystem::isScriptingSupported(ScriptId script)
 	case ApiSystem::THEMESDOWNLOADER:
 		return true;
 	case ApiSystem::RETROACHIVEMENTS:
-#ifdef CHEEVOS_DEV_LOGIN
-		return true;
-#endif
+		if (SystemConf::getInstance()->get("global.retroachievements.webapikey") != "") {
+			return true;
+		}
 		break;
 	case ApiSystem::KODI:
 		executables.push_back("kodi");

--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -224,9 +224,10 @@ GameInfoAndUserProgress RetroAchievements::getGameInfoAndUserProgress(int gameId
 	GameInfoAndUserProgress ret;
 	ret.ID = 0;
 
-#ifndef CHEEVOS_DEV_LOGIN
-	return ret;
-#endif
+	std::string webApiKey = SystemConf::getInstance()->get("global.retroachievements.webapikey");
+	if (webApiKey.empty()) {
+		return ret;
+	}
 
 	auto options = getHttpOptions();
 	HttpReq httpreq(getApiUrl("API_GetGameInfoAndUserProgress", "u=" + HttpReq::urlEncode(usrName) + "&g=" + std::to_string(gameId)), &options);

--- a/es-app/src/RetroAchievements.cpp
+++ b/es-app/src/RetroAchievements.cpp
@@ -130,23 +130,29 @@ static HttpReqOptions getHttpOptions()
 {
 	HttpReqOptions options;
 
-#ifdef CHEEVOS_DEV_LOGIN
-	std::string ret = Utils::String::extractString(CHEEVOS_DEV_LOGIN, "z=", "&");
-	ret =  ret + "/" + Utils::String::replace(RESOURCE_VERSION_STRING, ",", ".");		 
-	options.userAgent = ret;
-#endif	
+	std::string userName = SystemConf::getInstance()->get("global.retroachievements.username");
+	if (!userName.empty()) {
+		std::string ret = userName;
+		ret =  ret + "/" + Utils::String::replace(RESOURCE_VERSION_STRING, ",", ".");
+		options.userAgent = ret;
+	}
 
 	return options;
 }
 
 std::string RetroAchievements::getApiUrl(const std::string& method, const std::string& parameters)
 {
-#ifdef CHEEVOS_DEV_LOGIN
-	auto options = std::string(CHEEVOS_DEV_LOGIN);
-	return "https://retroachievements.org/API/"+ method +".php?"+ options +"&" + parameters;
-#else 
-	return "https://retroachievements.org/API/" + method + ".php?" + parameters;
-#endif
+	std::string userName = SystemConf::getInstance()->get("global.retroachievements.username");
+	std::string webApiKey = SystemConf::getInstance()->get("global.retroachievements.webapikey");
+
+	if (!userName.empty() && !webApiKey.empty()) {
+		auto options = "z=" + userName + "&y=" + webApiKey;
+		return "https://retroachievements.org/API/"+ method +".php?"+ options +"&" + parameters;
+	}
+	else
+	{
+		return "https://retroachievements.org/API/" + method + ".php?" + parameters;
+	}
 }
 
 std::string GameInfoAndUserProgress::getImageUrl(const std::string& image)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -146,7 +146,8 @@ GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(win
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::RETROACHIVEMENTS) &&
 		SystemConf::getInstance()->getBool("global.retroachievements") &&
 		Settings::getInstance()->getBool("RetroachievementsMenuitem") && 
-		SystemConf::getInstance()->get("global.retroachievements.username") != "")
+		SystemConf::getInstance()->get("global.retroachievements.username") != "" &&
+		SystemConf::getInstance()->get("global.retroachievements.webapikey") != "")
 		addEntry(_("RETROACHIEVEMENTS").c_str(), true, [this] {
 				if (!checkNetwork())
 					return;
@@ -2575,7 +2576,7 @@ void GuiMenu::openGamesSettings()
 	// Game List Update
 	s->addEntry(_("UPDATE GAMELISTS"), false, [this, window] { updateGameLists(window); });
 
-	if (SystemConf::getInstance()->getBool("global.retroachievements") && !Settings::getInstance()->getBool("RetroachievementsMenuitem") && SystemConf::getInstance()->get("global.retroachievements.username") != "")
+	if (SystemConf::getInstance()->getBool("global.retroachievements") && !Settings::getInstance()->getBool("RetroachievementsMenuitem") && SystemConf::getInstance()->get("global.retroachievements.username") != "" && SystemConf::getInstance()->get("global.retroachievements.webapikey") != "")
 	{
 		s->addEntry(_("RETROACHIEVEMENTS").c_str(), true, [this] 
 		{ 

--- a/es-app/src/guis/GuiRetroAchievementsSettings.cpp
+++ b/es-app/src/guis/GuiRetroAchievementsSettings.cpp
@@ -16,6 +16,7 @@ GuiRetroAchievementsSettings::GuiRetroAchievementsSettings(Window* window) : Gui
 	bool retroachievementsEnabled = SystemConf::getInstance()->getBool("global.retroachievements");
 	std::string username = SystemConf::getInstance()->get("global.retroachievements.username");
 	std::string password = SystemConf::getInstance()->get("global.retroachievements.password");
+	std::string webApiKey = SystemConf::getInstance()->get("global.retroachievements.webapikey");
 
 	// retroachievements_enable
 	auto retroachievements_enabled = std::make_shared<SwitchComponent>(mWindow);
@@ -25,6 +26,7 @@ GuiRetroAchievementsSettings::GuiRetroAchievementsSettings(Window* window) : Gui
 	// retroachievements, username, password
 	addInputTextRow(_("USERNAME"), "global.retroachievements.username", false);
 	addInputTextRow(_("PASSWORD"), "global.retroachievements.password", true);
+	addInputTextRow(_("API KEY"), "global.retroachievements.webapikey", true);
 
 	addGroup(_("OPTIONS"));
 
@@ -71,6 +73,7 @@ GuiRetroAchievementsSettings::GuiRetroAchievementsSettings(Window* window) : Gui
 		bool newState = retroachievements_enabled->getState();
 		std::string newUsername = SystemConf::getInstance()->get("global.retroachievements.username");
 		std::string newPassword = SystemConf::getInstance()->get("global.retroachievements.password");
+		std::string newWebApiKey = SystemConf::getInstance()->get("global.retroachievements.webapikey");
 		std::string token = SystemConf::getInstance()->get("global.retroachievements.token");
 
 		if (newState && (!retroachievementsEnabled || username != newUsername || password != newPassword || token.empty()))


### PR DESCRIPTION
This code compiles, I have no idea if it **works** though.

What it is supposed to do:

* Add the option to add an API key to the RetroAchievement settings where you put your credentials
* Hide the *RetroAchievements* menu from Main Menu and Game Settings **unless** the user has added their API key
* Use said API key **instead** of the `CHEEVOS_DEV_LOGIN` when establishing connection to RA

Not sure if it will work, but it's possible. Let's try and discuss?