### PR TITLE
Added battery saving settings

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -758,7 +758,6 @@ void GuiMenu::openPowerManagementSettings()
 	{
 		SystemConf::getInstance()->set("system.batterysavertimer", std::to_string((int)Math::round(newVal)));
 		SystemConf::getInstance()->saveSystemConf();
-		s->setVariable("exitreboot", true);
 	});
 	s->addWithLabel(_("BATTERY SAVING TIMER"), sliderBatterySaverTime);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -739,7 +739,7 @@ void GuiMenu::openPowerManagementSettings()
 	{
 	  if (optionsBatterySaveMode->changed())
 	  {
-	    SystemConf::getInstance()->set("system.batterysavermode", optionsRotation->getSelected());
+	    SystemConf::getInstance()->set("system.batterysavermode", optionsBatterySaveMode->getSelected());
 	    SystemConf::getInstance()->saveSystemConf();
 		s->setVariable("exitreboot", true);
 	  }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -727,7 +727,7 @@ void GuiMenu::openPowerManagementSettings()
 
 	std::string selectedBatteryMode = SystemConf::getInstance()->get("system.batterysavermode");
 	if (selectedBatteryMode.empty())
-		selectedBatteryMode = "DIM";
+		selectedBatteryMode = "dim";
 
 	optionsBatterySaveMode->add(_("DIM"),            "dim", selectedBatteryMode == "dim");
 	optionsBatterySaveMode->add(_("SUSPEND"),        "suspend", selectedBatteryMode == "suspend");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -749,7 +749,7 @@ void GuiMenu::openPowerManagementSettings()
 	auto sliderBatterySaverTime = std::make_shared<SliderComponent>(mWindow, 0.f, 7200.f, 30.f, "s");
 
 	int selectedBatterySaverTime = 120;
-	std::string configuredBatterySaverTime = SystemConf::getInstance()->get("system.batterysavermode");
+	std::string configuredBatterySaverTime = SystemConf::getInstance()->get("system.batterysavertimer");
 	if (!configuredBatterySaverTime.empty()) {
 		selectedBatterySaverTime = Utils::String::toInteger(configuredBatterySaverTime);
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -754,10 +754,11 @@ void GuiMenu::openPowerManagementSettings()
 		selectedBatterySaverTime = Utils::String::toInteger(configuredBatterySaverTime);
 	}
 	sliderBatterySaverTime->setValue((float)(selectedBatterySaverTime));
-	sliderBatterySaverTime->setOnValueChanged([](const float &newVal)
+	sliderBatterySaverTime->setOnValueChanged([s](const float &newVal)
 	{
 		SystemConf::getInstance()->set("system.batterysavertimer", std::to_string((int)Math::round(newVal)));
 		SystemConf::getInstance()->saveSystemConf();
+		s->setVariable("exitreboot", true);
 	});
 	s->addWithLabel(_("BATTERY SAVING TIMER"), sliderBatterySaverTime);
 

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -61,6 +61,7 @@ private:
         void openMultiScreensSettings();
         void openDmdSettings();
         void openDeveloperSettings();
+        void openPowerManagementSettings();
         void openNetplaySettings(); 
         void openRetroachievementsSettings();
         void openMissingBiosSettings();


### PR DESCRIPTION
The new battery save stuff by @Mikhailzrick lacked a GUI - it could only be edited via `batocera.conf`.

I have added a new *Power Management* menu to the *System Settings* of ES where both values can now be set up directly.

This time, I actually managed to **compile**, **run**, and **test** the code locally. Code seems to work fine, menu shows up and values are stored as expected.


![Screenshot_20241115_231729](https://github.com/user-attachments/assets/fac8814d-2d29-45be-8786-fa5dcbc9f1ea)
![Screenshot_20241115_235750](https://github.com/user-attachments/assets/9a29396f-14af-49ea-b46a-978916727599)
