### PR TITLE
Fire "config-changed" event when batocera.conf was updated

### DIFF
--- a/es-core/src/SystemConf.cpp
+++ b/es-core/src/SystemConf.cpp
@@ -4,6 +4,7 @@
 #include "Log.h"
 #include "utils/StringUtil.h"
 #include "utils/FileSystemUtil.h"
+#include "Scripting.h"
 #include "Settings.h"
 #include "Paths.h"
 
@@ -129,7 +130,7 @@ bool SystemConf::saveSystemConf()
 		filein.close();
 	}
 
-	static std::string removeID = "$^é(p$^mpv$êrpver$^vper$vper$^vper$vper$vper$^vperv^pervncvizn";
+	static std::string removeID = "$^ï¿½(p$^mpv$ï¿½rpver$^vper$vper$^vper$vper$vper$^vperv^pervncvizn";
 
 	int lastTime = SDL_GetTicks();
 
@@ -204,6 +205,8 @@ bool SystemConf::saveSystemConf()
 
 	remove(mSystemConfFileTmp.c_str());
 	changedConf.clear();
+
+	Scripting::fireEvent("config-changed");
 
 	return true;
 }


### PR DESCRIPTION
Until now, the `"config-changed"` event was only fired when **EmulationStation** settings have changed via `Settings.cpp`. However, `batocera.conf` is handled in a different wrapper called `SystemConf.cpp`. I made sure that when `SystemConf.cpp` updates `batocera.conf`, the event is also fired.

When the event is called, the **only** event handling is that all scripts in `/usr/share/emulationstation/scripts/<eventname>` and `/userdata/system/configs/emulationstation/scripts/<eventname>` are executed. Those folders are empty, except for the hooks that we added ourselves, so this move should be save.