### PR TITLE
Switch WatchersManager::run() from SDL_Tick() to std::chrono::system_clock::now()

### DIFF
--- a/es-core/src/watchers/WatchersManager.cpp
+++ b/es-core/src/watchers/WatchersManager.cpp
@@ -43,7 +43,7 @@ void WatchersManager::ResetComponent(IWatcher* instance)
 	{
 		if (comp->component == instance)
 		{
-			comp->nextCheckTime = std::chrono::system_clock::now();
+			comp->nextCheckTime = std::chrono::steady_clock::now();
 			return;
 		}
 	}
@@ -55,7 +55,7 @@ void WatchersManager::RegisterComponent(IWatcher* instance)
 
 	WatcherInfo* info = new WatcherInfo();
 	info->component = instance;
-	info->nextCheckTime = std::chrono::system_clock::now() + std::chrono::milliseconds(instance->initialUpdateTime());
+	info->nextCheckTime = std::chrono::steady_clock::now() + std::chrono::milliseconds(instance->initialUpdateTime());
 	mWatchers.push_back(info);
 }
 
@@ -145,7 +145,7 @@ void WatchersManager::run()
 		{
 			std::unique_lock<std::mutex> lock(mWatchersLock);
 
-			auto now = std::chrono::system_clock::now();
+			auto now = std::chrono::steady_clock::now();
 
 			for (auto item : mWatchers)
 			{

--- a/es-core/src/watchers/WatchersManager.cpp
+++ b/es-core/src/watchers/WatchersManager.cpp
@@ -145,7 +145,8 @@ void WatchersManager::run()
 		{
 			std::unique_lock<std::mutex> lock(mWatchersLock);
 
-			int ticks = SDL_GetTicks();
+			int ticks = static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+
 			for (auto item : mWatchers)
 			{
 				if (!mRunning)
@@ -160,7 +161,8 @@ void WatchersManager::run()
 				if (item->component->check())
 					NotifyComponentChanged(item->component);
 
-				item->nextCheckTime = SDL_GetTicks() + item->component->updateTime();
+				item->nextCheckTime = ticks + item->component->updateTime();
+
 			}
 		}		
 	}

--- a/es-core/src/watchers/WatchersManager.h
+++ b/es-core/src/watchers/WatchersManager.h
@@ -64,10 +64,10 @@ private:
 
 	struct WatcherInfo
 	{
-		WatcherInfo() { component = nullptr; nextCheckTime = std::chrono::system_clock::now(); }
+		WatcherInfo() { component = nullptr; nextCheckTime = std::chrono::steady_clock::now(); }
 
 		IWatcher*	component;
-		std::chrono::time_point<std::chrono::system_clock>	nextCheckTime;
+		std::chrono::time_point<std::chrono::steady_clock>	nextCheckTime;
 	};
 
 	void NotifyComponentChanged(IWatcher* component);

--- a/es-core/src/watchers/WatchersManager.h
+++ b/es-core/src/watchers/WatchersManager.h
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <list>
+#include <chrono>
 
 class WatchersManager;
 
@@ -63,10 +64,10 @@ private:
 
 	struct WatcherInfo
 	{
-		WatcherInfo() { component = nullptr; nextCheckTime = 0; }
+		WatcherInfo() { component = nullptr; nextCheckTime = std::chrono::system_clock::now(); }
 
 		IWatcher*	component;
-		int			nextCheckTime;
+		std::chrono::time_point<std::chrono::system_clock>	nextCheckTime;
 	};
 
 	void NotifyComponentChanged(IWatcher* component);


### PR DESCRIPTION
This is related to this issue: https://github.com/knulli-cfw/distribution/issues/126

**Bug**
When an SDL application starts up (e.g. GBA emulator) the tick value returned from SDL_GetTick() can reset to 0.

As an example, if the tick value gets up to 60 minutes, then gets reset, it could be another 60 minutes before the check() routine is ran as it needs to surpass its last check time (SDL_GetTick() + nextCheckTime.)

**The Change**
- Changed to use time_point<system_clock> instead of an int to track the current time.
- Uses system_clock::now() instead of SDL_GetTick                          