### PR TITLE
Bugs/sdl gettick reset

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1802,8 +1802,6 @@ std::vector<std::string> ApiSystem::extractPdfImages(const std::string& fileName
 		int hardWareCoreCount = std::thread::hardware_concurrency();
 		if (hardWareCoreCount > 1)
 		{
-			int lastTime = SDL_GetTicks();
-
 			int numberOfPagesToProcess = 1;
 			if (hardWareCoreCount < 8)
 				numberOfPagesToProcess = 2;
@@ -1817,9 +1815,6 @@ std::vector<std::string> ApiSystem::extractPdfImages(const std::string& fileName
 					pool.queueWorkItem([this, fileName, i, numberOfPagesToProcess] { extractPdfImages(fileName, i + 1, numberOfPagesToProcess); });
 
 				pool.wait();
-
-				int time = SDL_GetTicks() - lastTime;
-				std::string timeText = std::to_string(time) + "ms";
 
 				for (auto file : Utils::FileSystem::getDirContent(pdfFolder, false))
 				{
@@ -1836,8 +1831,6 @@ std::vector<std::string> ApiSystem::extractPdfImages(const std::string& fileName
 			return ret;
 		}
 	}
-
-	int lastTime = SDL_GetTicks();
 
 	std::string page;
 
@@ -1865,9 +1858,6 @@ std::vector<std::string> ApiSystem::extractPdfImages(const std::string& fileName
 	executeEnumerationScript("pdftoppm -jpeg -r "+ squality +" -cropbox" + page + " \"" + fileName + "\" \"" + pdfFolder + "/" + prefix + "\"");
 #endif
 
-	int time = SDL_GetTicks() - lastTime;
-	std::string text = std::to_string(time);
-	
 	for (auto file : Utils::FileSystem::getDirContent(pdfFolder, false))
 	{
 		auto ext = Utils::String::toLower(Utils::FileSystem::getExtension(file));
@@ -1883,7 +1873,6 @@ std::vector<std::string> ApiSystem::extractPdfImages(const std::string& fileName
 	std::sort(ret.begin(), ret.end());
 	return ret;
 }
-
 
 std::vector<PacmanPackage> ApiSystem::getBatoceraStorePackages()
 {

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -382,7 +382,7 @@ void playVideo()
 	vid.onShow();
 	vid.topWindow(true);
 
-	int lastTime = SDL_GetTicks();
+    auto lastTime = std::chrono::steady_clock::now();
 	int totalTime = 0;
 
 	while (!exitLoop)
@@ -399,19 +399,16 @@ void playVideo()
 			while (SDL_PollEvent(&event));
 		}
 
-		int curTime = SDL_GetTicks();
-		int deltaTime = curTime - lastTime;
+        auto deltaTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - lastTime);
 
 		if (vid.isPlaying())
 		{
-			totalTime += deltaTime;
-
-			if (gPlayVideoDuration > 0 && totalTime > gPlayVideoDuration * 100)
+			if (gPlayVideoDuration > 0 && deltaTime.count() > gPlayVideoDuration * 100)
 				break;
 		}
 
 		Transform4x4f transform = Transform4x4f::Identity();
-		vid.update(deltaTime);
+		vid.update(deltaTime.count());
 		vid.render(transform);
 
 		Renderer::swapBuffers();

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -707,7 +707,7 @@ int main(int argc, char* argv[])
 		}
 
 		auto curTime = std::chrono::steady_clock::now();
-		int deltaTime = std::chrono::duration_cast<std::chrono::milliseconds>(curTime - ps_time).count();
+		int deltaTime = std::chrono::duration_cast<std::chrono::milliseconds>(curTime - lastTime).count();
 
 		lastTime = curTime;
 

--- a/es-app/src/scrapers/Scraper.h
+++ b/es-app/src/scrapers/Scraper.h
@@ -10,6 +10,7 @@
 #include <queue>
 #include <utility>
 #include <set>
+#include <chrono>
 #include <assert.h>
 #include "FileData.h"
 
@@ -101,7 +102,8 @@ private:
 	HttpReqOptions mOptions;
 	int	mRetryCount;
 
-	int mOverQuotaPendingTime;
+	std::chrono::steady_clock::time_point mOverQuotaPendingTime;
+    bool mOverQuotaPending = false;
 	int mOverQuotaRetryDelay;
 	int mOverQuotaRetryCount;
 };
@@ -141,13 +143,14 @@ private:
 	HttpReq* mRequest;
 
 	int	mRetryCount;
-	int mOverQuotaPendingTime;
+	std::chrono::steady_clock::time_point mOverQuotaPendingTime;
 	int mOverQuotaRetryDelay;
 	int mOverQuotaRetryCount;
 
 	std::string mSavePath;
 	int mMaxWidth;
 	int mMaxHeight;
+    bool mOverQuotaPending=false;
 };
 
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -1195,7 +1195,7 @@ void ViewController::reloadAll(Window* window, bool reloadTheme)
 
 	if (gameListCount > 0)
 	{
-		int lastTime = SDL_GetTicks() - 50;
+        auto lastTime = std::chrono::system_clock::now() - std::chrono::milliseconds(50);
 
 		if (window)
 			window->renderSplashScreen(_("Loading gamelists"), 0.0f);
@@ -1217,10 +1217,11 @@ void ViewController::reloadAll(Window* window, bool reloadTheme)
 			
 			idx++;
 
-			int time = SDL_GetTicks();
-			if (window && time - lastTime >= 20)
+            auto now = std::chrono::system_clock::now();
+
+			if (window && std::chrono::duration_cast<std::chrono::milliseconds>(now - lastTime).count() >= 20)
 			{
-				lastTime = time;
+				lastTime = now;
 				window->renderSplashScreen(_("Loading gamelists"), (float)idx / (float)gameListCount);
 			}
 		}

--- a/es-core/src/SystemConf.cpp
+++ b/es-core/src/SystemConf.cpp
@@ -1,6 +1,7 @@
 #include "SystemConf.h"
 #include <iostream>
 #include <fstream>
+#include <chrono>
 #include "Log.h"
 #include "utils/StringUtil.h"
 #include "utils/FileSystemUtil.h"
@@ -132,7 +133,7 @@ bool SystemConf::saveSystemConf()
 
 	static std::string removeID = "$^�(p$^mpv$�rpver$^vper$vper$^vper$vper$vper$^vperv^pervncvizn";
 
-	int lastTime = SDL_GetTicks();
+	auto lastTime = std::chrono::steady_clock::now();
 
 	/* Save new value if exists */
 	for (auto& it : changedConf)
@@ -181,9 +182,7 @@ bool SystemConf::saveSystemConf()
 		}
 	}
 
-	lastTime = SDL_GetTicks() - lastTime;
-
-	LOG(LogDebug) << "saveSystemConf :  " << lastTime;
+	LOG(LogDebug) << "saveSystemConf :  " << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - lastTime).count();
 
 	std::ofstream fileout(mSystemConfFileTmp); //Temporary file
 	if (!fileout)

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -358,7 +358,7 @@ void VideoComponent::handleStartDelay()
 		return;
 
 	// Timeout not yet completed
-	if (mStartTime > SDL_GetTicks())
+	if (mStartTime > std::chrono::steady_clock::now())
 		return;
 
 	// Completed
@@ -421,7 +421,7 @@ void VideoComponent::startVideoWithDelay()
 		// Configure the start delay
 		mStartDelayed = true;
 		mFadeIn = 0.0f;
-		mStartTime = SDL_GetTicks() + mConfig.startDelay;
+		mStartTime = std::chrono::steady_clock::now() + std::chrono::milliseconds(mConfig.startDelay);
 	}
 }
 
@@ -436,10 +436,10 @@ void VideoComponent::update(int deltaTime)
 
 		if (mStartDelayed)
 		{
-			Uint32 ticks = SDL_GetTicks();
-			if (mStartTime > ticks)
+            auto now = std::chrono::steady_clock::now();
+			if (mStartTime > now)
 			{
-				Uint32 diff = mStartTime - ticks;
+				Uint32 diff = std::chrono::duration_cast<std::chrono::milliseconds>(mStartTime - now).count();
 				if (diff < FADE_TIME_MS)
 				{
 					mFadeIn = (float)diff / (float)FADE_TIME_MS;

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 #ifndef ES_CORE_COMPONENTS_VIDEO_COMPONENT_H
 #define ES_CORE_COMPONENTS_VIDEO_COMPONENT_H
-
+#include <chrono>
 #include "components/ImageComponent.h"
 #include "components/ImageGridComponent.h"
 #include "GuiComponent.h"
@@ -193,36 +193,36 @@ private:
 	void manageState();
 
 protected:
-	unsigned						mVideoWidth;
-	unsigned						mVideoHeight;
-	Vector2f						mTargetSize;
-	std::shared_ptr<TextureResource> mTexture;
-	float							mFadeIn;
-	std::string						mStaticImagePath;
-	ImageComponent					mStaticImage;
-	bool							mPlayAudio;
+	unsigned								mVideoWidth;
+	unsigned								mVideoHeight;
+	Vector2f								mTargetSize;
+	std::shared_ptr<TextureResource> 		mTexture;
+	float									mFadeIn;
+	std::string								mStaticImagePath;
+	ImageComponent							mStaticImage;
+	bool									mPlayAudio;
 
-	std::string						mVideoPath;
-	std::string						mPlayingVideoPath;
+	std::string								mVideoPath;
+	std::string								mPlayingVideoPath;
 
-	std::string						mThemedPath;
+	std::string								mThemedPath;
 
-	bool							mStartDelayed;
-	unsigned						mStartTime;
-	bool							mIsPlaying;		
-	bool							mScreensaverActive;
-	bool							mScreensaverMode;
-	bool							mTargetIsMax;
-	bool							mTargetIsMin;
+	bool									mStartDelayed;
+	std::chrono::steady_clock::time_point	mStartTime;
+	bool									mIsPlaying;
+	bool									mScreensaverActive;
+	bool									mScreensaverMode;
+	bool									mTargetIsMax;
+	bool									mTargetIsMin;
 
-	bool							mIsWaitingForVideoToStart;
+	bool									mIsWaitingForVideoToStart;
 
-	bool							mIsTopWindow;
-	bool							mEnabled;
+	bool									mIsTopWindow;
+	bool									mEnabled;
 
-	float							mRoundCorners;
+	float									mRoundCorners;
 
-	Configuration					mConfig;
+	Configuration							mConfig;
 };
 
 #endif // ES_CORE_COMPONENTS_VIDEO_COMPONENT_H

--- a/es-core/src/guis/GuiInfoPopup.cpp
+++ b/es-core/src/guis/GuiInfoPopup.cpp
@@ -58,7 +58,7 @@ GuiInfoPopup::GuiInfoPopup(Window* window, std::string message, int duration) :
 	addChild(mFrame);
 
 	// we only init the actual time when we first start to render
-	mStartTime = 0;
+	mStarted = false;
 
 	mGrid = new ComponentGrid(window, Vector2i(1, 3));
 	mGrid->setSize(mSize);
@@ -82,12 +82,15 @@ void GuiInfoPopup::update(int deltaTime)
 {
 	GuiComponent::update(deltaTime);
 
-	int curTime = SDL_GetTicks();
+    auto curTime = std::chrono::steady_clock::now();
 
 	// we only init the actual time when we first start to render
-	if (mStartTime == 0)
+	if (!mStarted)
+    {
 		mStartTime = curTime;
-	else if (curTime - mStartTime > mDuration || curTime < mStartTime)
+        mStarted = true;
+    }
+	else if (std::chrono::duration_cast<std::chrono::milliseconds>(curTime - mStartTime).count() > mDuration || curTime < mStartTime)
 	{
 		// If we're past the popup duration, no need to render or if SDL reset : Stop
 		mRunning = false;
@@ -100,11 +103,11 @@ void GuiInfoPopup::update(int deltaTime)
 	// compute fade in effect
 	int alpha = 255;
 
-	if (curTime - mStartTime <= FADE_DURATION)
-		alpha = ((curTime - mStartTime) * 255 / FADE_DURATION);
-	else if (curTime - mStartTime >= mDuration - FADE_DURATION)
+	if (std::chrono::duration_cast<std::chrono::milliseconds>(curTime - mStartTime).count() <= FADE_DURATION)
+		alpha = ((std::chrono::duration_cast<std::chrono::milliseconds>(curTime - mStartTime).count()) * 255 / FADE_DURATION);
+	else if (std::chrono::duration_cast<std::chrono::milliseconds>(curTime - mStartTime).count() >= mDuration - FADE_DURATION)
 	{
-		alpha = ((-(curTime - mStartTime - mDuration) * 255) / FADE_DURATION);
+		alpha = ((-(std::chrono::duration_cast<std::chrono::milliseconds>(curTime - mStartTime).count() - mDuration) * 255) / FADE_DURATION);
 		mFadeOut = (float) (255 - alpha) / 255.0;
 	}
 

--- a/es-core/src/guis/GuiInfoPopup.h
+++ b/es-core/src/guis/GuiInfoPopup.h
@@ -1,7 +1,7 @@
 #pragma once
 #ifndef ES_APP_GUIS_GUI_INFO_POPUP_H
 #define ES_APP_GUIS_GUI_INFO_POPUP_H
-
+#include <chrono>
 #include "GuiComponent.h"
 #include "Window.h"
 
@@ -22,16 +22,17 @@ public:
 	std::string         getMessage() { return mMessage; }
 
 private:
-	std::string         mMessage;
+	std::string         					mMessage;
 
-	int                 mStartTime;
-	int                 mDuration;
-	bool                mRunning;	
+    bool                					mStarted=false;
+	std::chrono::steady_clock::time_point	mStartTime;
+	int                 					mDuration;
+	bool                					mRunning;
 
-	float				mFadeOut;
+	float									mFadeOut;
 
-	ComponentGrid*      mGrid;
-	NinePatchComponent* mFrame;
+	ComponentGrid*      					mGrid;
+	NinePatchComponent* 					mFrame;
 };
 
 #endif // ES_APP_GUIS_GUI_INFO_POPUP_H


### PR DESCRIPTION
Fix usage of SDL_GetTicks() throughout ES.  This is separate from the issue causing the Battery % as these changes can have a more widespread impact.

The general fix is to convert from using SDL_GetTicks() which can be reset to 0 to use std::chrono::steady_clock.