### PR TITLE
Quick Resume Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,13 @@ Makefile
 CPackConfig.cmake
 CPackSourceConfig.cmake
 
+# VS Code
+/.vscode
+*.code-workspace
+/.vs/
+
 # batocera
 # po backup
 *.po~
-/.vs/
 *.sqlite
 .DS_Store

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -696,6 +696,8 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	if (command.empty())
 		return false;
 
+	std::string quickResumeCommand = getlaunchCommand(false);
+
 	AudioManager::getInstance()->deinit();
 	VolumeControl::getInstance()->deinit();
 
@@ -704,6 +706,13 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	
 	const std::string rom = Utils::FileSystem::getEscapedPath(getPath());
 	const std::string basename = Utils::FileSystem::getStem(getPath());
+
+	if (!quickResumeCommand.empty() && SystemConf::getInstance()->getBool("global.quickresumemode") == true)
+	{
+		SystemConf::getInstance()->set("global.bootgame.path", getFullPath());
+		SystemConf::getInstance()->set("global.bootgame.cmd", quickResumeCommand);
+		SystemConf::getInstance()->saveSystemConf();
+	}
 
 	Scripting::fireEvent("game-start", rom, basename, getName());
 

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -703,6 +703,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	if (command.empty())
 		return false;
 
+#if Knulli
 	if (SystemConf::getInstance()->getBool("global.quickresumemode") == true)
 	{
 		std::string quickResumeCommand = getlaunchCommand(false);
@@ -712,6 +713,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		else
 			LOG(LogWarning) << "...quick resume command was empty!";
 	}
+#endif
 
 	AudioManager::getInstance()->deinit();
 	VolumeControl::getInstance()->deinit();

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -703,7 +703,6 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	if (command.empty())
 		return false;
 
-#if Knulli
 	if (SystemConf::getInstance()->getBool("global.quickresumemode") == true)
 	{
 		std::string quickResumeCommand = getlaunchCommand(false);
@@ -713,7 +712,6 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		else
 			LOG(LogWarning) << "...quick resume command was empty!";
 	}
-#endif
 
 	AudioManager::getInstance()->deinit();
 	VolumeControl::getInstance()->deinit();

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -696,7 +696,15 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	if (command.empty())
 		return false;
 
+	// KNULLI - QUICK RESUME MODE >>>
 	std::string quickResumeCommand = getlaunchCommand(false);
+	if (!quickResumeCommand.empty() && SystemConf::getInstance()->getBool("global.quickresume") == true)
+	{
+		SystemConf::getInstance()->set("global.bootgame.path", getFullPath());
+		SystemConf::getInstance()->set("global.bootgame.cmd", quickResumeCommand);
+		SystemConf::getInstance()->saveSystemConf();
+	}
+	// KNULLI - QUICK RESUME MODE <<<
 
 	AudioManager::getInstance()->deinit();
 	VolumeControl::getInstance()->deinit();
@@ -706,13 +714,6 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	
 	const std::string rom = Utils::FileSystem::getEscapedPath(getPath());
 	const std::string basename = Utils::FileSystem::getStem(getPath());
-
-	if (!quickResumeCommand.empty() && SystemConf::getInstance()->getBool("global.quickresumemode") == true)
-	{
-		SystemConf::getInstance()->set("global.bootgame.path", getFullPath());
-		SystemConf::getInstance()->set("global.bootgame.cmd", quickResumeCommand);
-		SystemConf::getInstance()->saveSystemConf();
-	}
 
 	Scripting::fireEvent("game-start", rom, basename, getName());
 

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -680,6 +680,13 @@ std::string FileData::getMessageFromExitCode(int exitCode)
 	return _("UKNOWN ERROR") + " : " + std::to_string(exitCode);
 }
 
+bool FileData::setQuickResumeCommand(std::string quickResumeCommand)
+{
+			SystemConf::getInstance()->set("global.bootgame.path", getFullPath());
+			SystemConf::getInstance()->set("global.bootgame.cmd", quickResumeCommand);
+			return SystemConf::getInstance()->saveSystemConf();
+}
+
 bool FileData::launchGame(Window* window, LaunchGameOptions options)
 {
 	LOG(LogInfo) << "Attempting to launch game...";
@@ -696,7 +703,17 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	if (command.empty())
 		return false;
 
-	std::string quickResumeCommand = getlaunchCommand(false);
+#if Knulli
+	if (SystemConf::getInstance()->getBool("global.quickresumemode") == true)
+	{
+		std::string quickResumeCommand = getlaunchCommand(false);
+		if (!quickResumeCommand.empty())
+			if (!setQuickResumeCommand(quickResumeCommand))
+				LOG(LogWarning) << "...quick resume command was not saved in batocera.conf!";
+		else
+			LOG(LogWarning) << "...quick resume command was empty!";
+	}
+#endif
 
 	AudioManager::getInstance()->deinit();
 	VolumeControl::getInstance()->deinit();
@@ -706,13 +723,6 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	
 	const std::string rom = Utils::FileSystem::getEscapedPath(getPath());
 	const std::string basename = Utils::FileSystem::getStem(getPath());
-
-	if (!quickResumeCommand.empty() && SystemConf::getInstance()->getBool("global.quickresumemode") == true)
-	{
-		SystemConf::getInstance()->set("global.bootgame.path", getFullPath());
-		SystemConf::getInstance()->set("global.bootgame.cmd", quickResumeCommand);
-		SystemConf::getInstance()->saveSystemConf();
-	}
 
 	Scripting::fireEvent("game-start", rom, basename, getName());
 

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -139,6 +139,7 @@ public:
 
 	std::string getlaunchCommand(bool includeControllers = true) { LaunchGameOptions options; return getlaunchCommand(options, includeControllers); };
 	std::string getlaunchCommand(LaunchGameOptions& options, bool includeControllers = true);
+	bool		setQuickResumeCommand(std::string quickResumeCommand);
 
 	bool		launchGame(Window* window, LaunchGameOptions options = LaunchGameOptions());
 

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -139,7 +139,6 @@ public:
 
 	std::string getlaunchCommand(bool includeControllers = true) { LaunchGameOptions options; return getlaunchCommand(options, includeControllers); };
 	std::string getlaunchCommand(LaunchGameOptions& options, bool includeControllers = true);
-	bool		setQuickResumeCommand(std::string quickResumeCommand);
 
 	bool		launchGame(Window* window, LaunchGameOptions options = LaunchGameOptions());
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2743,11 +2743,11 @@ void GuiMenu::openGamesSettings()
 	s->addWithDescription(_("SHOW SAVESTATE MANAGER"), _("Display savestate manager before launching a game."), showSaveStates);
 	s->addSaveFunc([showSaveStates] { SystemConf::getInstance()->set("global.savestates", showSaveStates->getSelected()); });
 
-	// // QUICK RESUME MODE
-	// auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
-	// quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
-	// s->addWithDescription(_("QUICK RESUME MODE"), _("Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit."), quickResumeMode);
-	// s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
+	// QUICK RESUME MODE
+	auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
+	quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
+	s->addWithDescription(_("QUICK RESUME MODE"), _("Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit."), quickResumeMode);
+	s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
 
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2746,7 +2746,7 @@ void GuiMenu::openGamesSettings()
 	// QUICK RESUME MODE
 	auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
 	quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
-	s->addWithDescription(_("QUICK RESUME MODE"), _("If a shutdown occurs during gameplay, next boot skips loading of ES and proceeds directly into the game. Works with auto save/load if supported by the emulator."), quickResumeMode);
+	s->addWithDescription(_("QUICK RESUME MODE"), _("Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit."), quickResumeMode);
 	s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
 
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2746,9 +2746,9 @@ void GuiMenu::openGamesSettings()
 	// QUICK RESUME MODE
 	auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
 	quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
-	s->addWithDescription(_("QUICK RESUME MODE"), _("If a shutdown occurs during gameplay, next boot skips loading of ES and proceeds directly into the game. Works with auto save/load if supported by the emulator."), quickResumeMode);
+	s->addWithDescription(_("QUICK RESUME MODE"), _("If shutdown during gameplay, next boot skips loading ES and proceeds directly into the game. Works with auto save/load if supported by the emulator."), quickResumeMode);
 	s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
-
+	
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));
 
 	// Screen ratio choice

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2726,14 +2726,6 @@ void GuiMenu::openGamesSettings()
 	s->addWithDescription(_("AUTO SAVE/LOAD"), _("Load latest savestate on game launch and savestate when exiting game."), autosave_enabled);
 	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getState() ? "1" : ""); });
 
-	// KNULLI - QUICK RESUME MODE >>>
-	// QUICK RESUME MODE
-	auto quickresume_enabled = std::make_shared<SwitchComponent>(mWindow);
-	quickresume_enabled->setState(SystemConf::getInstance()->get("global.quickresume") == "1");
-	s->addWithDescription(_("QUICK RESUME"), _("If shutdown occurs during gameplay, system will boot directly into game on next startup. Works with Auto Save/Load on supported emulators."), quickresume_enabled);
-	s->addSaveFunc([quickresume_enabled] { SystemConf::getInstance()->set("global.quickresume", quickresume_enabled->getState() ? "1" : ""); });
-	// KNULLI - QUICK RESUME MODE <<<
-
 	// INCREMENTAL SAVESTATES
 	auto incrementalSaveStates = std::make_shared<OptionListComponent<std::string>>(mWindow, _("INCREMENTAL SAVESTATES"));
 	incrementalSaveStates->addRange({
@@ -2750,6 +2742,14 @@ void GuiMenu::openGamesSettings()
 	showSaveStates->addRange({ { _("NO"), "auto" },{ _("ALWAYS") , "1" },{ _("IF NOT EMPTY") , "2" } }, SystemConf::getInstance()->get("global.savestates"));
 	s->addWithDescription(_("SHOW SAVESTATE MANAGER"), _("Display savestate manager before launching a game."), showSaveStates);
 	s->addSaveFunc([showSaveStates] { SystemConf::getInstance()->set("global.savestates", showSaveStates->getSelected()); });
+
+	// KNULLI - QUICK RESUME MODE >>>
+	// QUICK RESUME MODE
+	auto quickresume_enabled = std::make_shared<SwitchComponent>(mWindow);
+	quickresume_enabled->setState(SystemConf::getInstance()->get("global.quickresume") == "1");
+	s->addWithDescription(_("QUICK RESUME MODE"), _("If shutdown during gameplay, boots directly into game on next startup. Works with Auto Save/Load on supported emulators."), quickresume_enabled);
+	s->addSaveFunc([quickresume_enabled] { SystemConf::getInstance()->set("global.quickresume", quickresume_enabled->getState() ? "1" : ""); });
+	// KNULLI - QUICK RESUME MODE <<<
 
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2743,6 +2743,12 @@ void GuiMenu::openGamesSettings()
 	s->addWithDescription(_("SHOW SAVESTATE MANAGER"), _("Display savestate manager before launching a game."), showSaveStates);
 	s->addSaveFunc([showSaveStates] { SystemConf::getInstance()->set("global.savestates", showSaveStates->getSelected()); });
 
+	// QUICK RESUME MODE
+	auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
+	quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
+	s->addWithDescription(_("QUICK RESUME MODE"), _("Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit."), quickResumeMode);
+	s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
+
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));
 
 	// Screen ratio choice

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2726,6 +2726,14 @@ void GuiMenu::openGamesSettings()
 	s->addWithDescription(_("AUTO SAVE/LOAD"), _("Load latest savestate on game launch and savestate when exiting game."), autosave_enabled);
 	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getState() ? "1" : ""); });
 
+	// KNULLI - QUICK RESUME MODE >>>
+	// QUICK RESUME MODE
+	auto quickresume_enabled = std::make_shared<SwitchComponent>(mWindow);
+	quickresume_enabled->setState(SystemConf::getInstance()->get("global.quickresume") == "1");
+	s->addWithDescription(_("QUICK RESUME"), _("If shutdown occurs during gameplay, system will boot directly into game on next startup. Works with Auto Save/Load on supported emulators."), quickresume_enabled);
+	s->addSaveFunc([quickresume_enabled] { SystemConf::getInstance()->set("global.quickresume", quickresume_enabled->getState() ? "1" : ""); });
+	// KNULLI - QUICK RESUME MODE <<<
+
 	// INCREMENTAL SAVESTATES
 	auto incrementalSaveStates = std::make_shared<OptionListComponent<std::string>>(mWindow, _("INCREMENTAL SAVESTATES"));
 	incrementalSaveStates->addRange({
@@ -2742,12 +2750,6 @@ void GuiMenu::openGamesSettings()
 	showSaveStates->addRange({ { _("NO"), "auto" },{ _("ALWAYS") , "1" },{ _("IF NOT EMPTY") , "2" } }, SystemConf::getInstance()->get("global.savestates"));
 	s->addWithDescription(_("SHOW SAVESTATE MANAGER"), _("Display savestate manager before launching a game."), showSaveStates);
 	s->addSaveFunc([showSaveStates] { SystemConf::getInstance()->set("global.savestates", showSaveStates->getSelected()); });
-
-	// QUICK RESUME MODE
-	auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
-	quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
-	s->addWithDescription(_("QUICK RESUME MODE"), _("Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit."), quickResumeMode);
-	s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
 
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2746,9 +2746,9 @@ void GuiMenu::openGamesSettings()
 	// QUICK RESUME MODE
 	auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
 	quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
-	s->addWithDescription(_("QUICK RESUME MODE"), _("If shutdown during gameplay, next boot skips loading ES and proceeds directly into the game. Works with auto save/load if supported by the emulator."), quickResumeMode);
+	s->addWithDescription(_("QUICK RESUME MODE"), _("If a shutdown occurs during gameplay, next boot skips loading of ES and proceeds directly into the game. Works with auto save/load if supported by the emulator."), quickResumeMode);
 	s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
-	
+
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));
 
 	// Screen ratio choice

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2743,11 +2743,11 @@ void GuiMenu::openGamesSettings()
 	s->addWithDescription(_("SHOW SAVESTATE MANAGER"), _("Display savestate manager before launching a game."), showSaveStates);
 	s->addSaveFunc([showSaveStates] { SystemConf::getInstance()->set("global.savestates", showSaveStates->getSelected()); });
 
-	// QUICK RESUME MODE
-	auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
-	quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
-	s->addWithDescription(_("QUICK RESUME MODE"), _("Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit."), quickResumeMode);
-	s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
+	// // QUICK RESUME MODE
+	// auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
+	// quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
+	// s->addWithDescription(_("QUICK RESUME MODE"), _("Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit."), quickResumeMode);
+	// s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
 
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2746,7 +2746,7 @@ void GuiMenu::openGamesSettings()
 	// QUICK RESUME MODE
 	auto quickResumeMode = std::make_shared<SwitchComponent>(mWindow);
 	quickResumeMode->setState(SystemConf::getInstance()->get("global.quickresumemode") == "1");
-	s->addWithDescription(_("QUICK RESUME MODE"), _("Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit."), quickResumeMode);
+	s->addWithDescription(_("QUICK RESUME MODE"), _("If a shutdown occurs during gameplay, next boot skips loading of ES and proceeds directly into the game. Works with auto save/load if supported by the emulator."), quickResumeMode);
 	s->addSaveFunc([quickResumeMode] { SystemConf::getInstance()->set("global.quickresumemode", quickResumeMode->getState() ? "1" : ""); });
 
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+PWD=$(pwd)
+rm -rf ~/source/knulli-distribution/dl/batocera-emulationstation/
+rm -rf ~/source/knulli-distribution/output/h700/build/batocera-emulationstation-knulli/
+cd ~/source/knulli-distribution/
+make h700-pkg PKG=batocera-emulationstation
+cd $PWD
+echo "Build complete."

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+PWD=$(pwd)
+scp -rv ~/source/knulli-distribution/output/h700/build/batocera-emulationstation-quick_resume_mode/emulationstation root@RG35XXSP:~/emulationstation.new
+ssh root@RG35XXSP "./es-kill.sh && echo \"killing ES...\" && sleep 7.5 && cp -rv ~/emulationstation.new /usr/bin/emulationstation && batocera-save-overlay && reboot"
+cd "$PWD"
+echo
+echo "Deployment complete."
+echo


### PR DESCRIPTION
These components implement a Quick Resume Mode. This implementation mostly 

leverages existing Batocera features such as the _Launch This Game on Startup_ feature. This component automates the management of `global.bootgame.cmd` and `global.bootgame.path` settings within the `batocera.conf` configuration file.

Description from the ES settings menu:
> Boots directly from the last played game if shutdown during gameplay. Works with auto save/load. Reduces boot time by scanning games, laoding ES, after game exit.

When in this mode, if you power down from ES, you will boot back in to ES. When booting a game in this mode, WIFI and Bluetooth are restored prior to game load which means RetroAchievements is supported.

The following script `quick_resume_mode.sh` needs to reside in `userdata/system/scripts` in order for this feature to work:
```shell script
#!/bin/bash
LOG_FILE=/userdata/system/logs/quick-resume.log
SHUTDOWN_FLAG=/var/run/shutdown-ingame.flag

# Ensure the log file exists
[ ! -f "$LOG_FILE" ] && touch "$LOG_FILE"

{
    echo "$(date '+%Y-%m-%d %H:%M:%S'): quick-resume-mode.sh starting."
    echo "The following parameters were passed to this script from ES: "
    echo "$@"

    # Case selection for first parameter parsed, our event.
    case $1 in
        gameStart)
            # Commands in here will be executed on the start of any game.
            echo "Now executing gameStart event."
        ;;
        gameStop)
            # Commands here will be executed on the stop of every game.
            echo "Now executing gameStop event."
            QUICK_RESUME_ENABLED=$(batocera-settings-get global.quickresume)
            if [ "$QUICK_RESUME_ENABLED" -eq 1 ]; then
                echo "Quick Resume is enabled. Checking shutdown status."
                if [ ! -f "$SHUTDOWN_FLAG" ]; then
                    batocera-settings-set global.bootgame.cmd ""
                    batocera-settings-set global.bootgame.path ""
                    echo "In-game shutdown not detected. Cleared global.bootgame settings from batocera.conf."
                else
                    echo "In-game shutdown detected. Retained global.bootgame settings in batocera.conf."
                fi
            else
                echo "Quick resume is not enabled. Nothing to do."
            fi
        ;;
    esac

    echo "$(date '+%Y-%m-%d %H:%M:%S'): quick-resume-mode.sh exiting."

} >> $LOG_FILE
```

<br/>

![knulli-screenshot](https://github.com/user-attachments/assets/6ac3f2af-73b3-4954-bdf8-5bc9028cbc1d)

https://github.com/user-attachments/assets/f86814e2-2471-4807-a71d-beb9e5d45e9b

