### PR TITLE
Quick Resume Mode - EmulationStation Enhancements

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -782,7 +782,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	}
 
 	// write out the debug log to assist with testing
-	Utils::FileSystem::writeAllText(quickResumeLog, logMessage);
+	Utils::FileSystem::writeAllText("/userdata/system/logs/quick-resume-testing.log", logMessage);
 	// KNULLI - QUICK RESUME MODE <<<
 
 	Scripting::fireEvent("game-end");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2743,6 +2743,14 @@ void GuiMenu::openGamesSettings()
 	s->addWithDescription(_("SHOW SAVESTATE MANAGER"), _("Display savestate manager before launching a game."), showSaveStates);
 	s->addSaveFunc([showSaveStates] { SystemConf::getInstance()->set("global.savestates", showSaveStates->getSelected()); });
 
+	// KNULLI - QUICK RESUME MODE >>>
+	// QUICK RESUME MODE
+	auto quickresume_enabled = std::make_shared<SwitchComponent>(mWindow);
+	quickresume_enabled->setState(SystemConf::getInstance()->get("global.quickresume") == "1");
+	s->addWithDescription(_("QUICK RESUME MODE"), _("If shutdown during gameplay, boots directly into game on next startup. Works with Auto Save/Load on supported emulators."), quickresume_enabled);
+	s->addSaveFunc([quickresume_enabled] { SystemConf::getInstance()->set("global.quickresume", quickresume_enabled->getState() ? "1" : ""); });
+	// KNULLI - QUICK RESUME MODE <<<
+
 	s->addGroup(_("DEFAULT GLOBAL SETTINGS"));
 
 	// Screen ratio choice


### PR DESCRIPTION
# Knulli
## Quick Resume Mode
Quick Resume Mode leverages the existing Batocera feature which allows the user to choose a game and, under _Advanced Options_, choose to _Launch on Boot_. This feature builds on top of that foundation and uses the existing code and solution components wherever possible in order to minimize the impact of receiving features from upstream.

The following is a slightly expanded description of how it's described in EmulationStation:
> If shutdown during gameplay, boots directly into game on next startup. Works with Auto Save/Load on supported emulators. Supports RetroAchievements on-resume.

### How it works:
Essentially, all this component does is automate the setting of _Launch on Boot_ for each game launched in this mode. If

This feature is driven by the following settings, located in the `batocera.conf` file:
* `global.bootgame.cmd`: string - command to be passed into `emulatorlauncher.py`
* `global.bootgame.path`: string - the non-escaped path to the ROM
* `global.quickresume`: boolean - set to 1 if quick resume is enbaled

