### PR TITLE
Changed steps of sliders, changed speed/brightness range to 0-100, re-enabled TrimUI achievements

### DIFF
--- a/es-app/src/guis/knulli/GuiRgbSettings.cpp
+++ b/es-app/src/guis/knulli/GuiRgbSettings.cpp
@@ -52,23 +52,23 @@ GuiRgbSettings::GuiRgbSettings(Window* window) : GuiSettings(window, _("RGB LED 
     optionListMode = createModeOptionList();
 
     // LED Brightness Slider
-    sliderLedBrightness = createSlider("BRIGHTNESS", 0.f, 255.f, 1.f, "", "", (isH700 || isA133));    
+    sliderLedBrightness = createSlider("BRIGHTNESS", 0.f, 100.f, 5.f, "", "", (isH700 || isA133));    
     setConfigValueForSlider(sliderLedBrightness, DEFAULT_BRIGHTNESS, "led.brightness");
 
     // Adaptive Brightness switch
     switchAdaptiveBrightness = createSwitch("ADAPTIVE BRIGHTNESS", "led.brightness.adaptive", "Automatically adapts LED brightness to screen brightness (based on the brightness setting above).", (isH700 || isA133));
 
     // LED Speed Slider
-    sliderLedSpeed = createSlider("SPEED", 1.f, 255.f, 1.f, "", "Not applicable for all devices/modes. Warning: High speed may cause seizures for people with photosensitive epilepsy.", isH700);
+    sliderLedSpeed = createSlider("SPEED", 1.f, 100.f, 5.f, "", "Not applicable for all devices/modes. Warning: High speed may cause seizures for people with photosensitive epilepsy.", isH700);
     setConfigValueForSlider(sliderLedSpeed, DEFAULT_SPEED, "led.speed");
 
     // LED Colour Sliders
     std::array<float, 3> rgbValues = getRgbValues();
-    sliderLedRed = createSlider("RED", 0.f, 255.f, 1.f, "", "", (isH700 || isA133));
+    sliderLedRed = createSlider("RED", 0.f, 255.f, 10.f, "", "", (isH700 || isA133));
     sliderLedRed->setValue(rgbValues[0]);
-    sliderLedGreen = createSlider("GREEN", 0.f, 255.f, 1.f, "", "", (isH700 || isA133));
+    sliderLedGreen = createSlider("GREEN", 0.f, 255.f, 10.f, "", "", (isH700 || isA133));
     sliderLedGreen->setValue(rgbValues[1]);
-    sliderLedBlue = createSlider("BLUE", 0.f, 255.f, 1.f, "", "", (isH700 || isA133));
+    sliderLedBlue = createSlider("BLUE", 0.f, 255.f, 10.f, "", "", (isH700 || isA133));
     sliderLedBlue->setValue(rgbValues[2]);
     addEntry(_("RESTORE DEFAULT COLORS"), true, [this] { restoreDefaultColors(); });
 
@@ -79,10 +79,9 @@ GuiRgbSettings::GuiRgbSettings(Window* window) : GuiSettings(window, _("RGB LED 
     setConfigValueForSlider(sliderLowBatteryThreshold, DEFAULT_LOW_BATTERY_THRESHOLD, "led.battery.low");
     switchBatteryCharging = createSwitch("BATTERY CHARGING", "led.battery.charging", "Show green breathing while device is charging.", (isH700 || isA133));
 
-    if (isH700) {
-        addGroup(_("RETRO ACHIEVEMENT INDICATION"));
-    }
-    switchRetroAchievements = createSwitch("ACHIEVEMENT EFFECT", "led.retroachievements", "Honor your retro achievements with a LED effect.", (isH700));
+
+    addGroup(_("RETRO ACHIEVEMENT INDICATION"));
+    switchRetroAchievements = createSwitch("ACHIEVEMENT EFFECT", "led.retroachievements", "Honor your retro achievements with a LED effect.", (isH700 || isA133));
 
     initializeOnChangeListeners();
     applyValues();

--- a/es-app/src/guis/knulli/Pico8Installer.cpp
+++ b/es-app/src/guis/knulli/Pico8Installer.cpp
@@ -21,7 +21,7 @@
 int Pico8Installer::install()
 {
 	if (hasInstaller()) {
-		int result = system("/usr/bin/install-pico8.sh");
+		int result = system("/usr/bin/knulli-install-pico8");
 		return WEXITSTATUS(result);
 	}
 	// Installer is missing

--- a/es-app/src/guis/knulli/RgbService.cpp
+++ b/es-app/src/guis/knulli/RgbService.cpp
@@ -7,8 +7,8 @@
 #include <sys/wait.h>
 #include <fstream>
 
-const std::string RGB_SERVICE_NAME = "/usr/bin/analog_stick_led_daemon.sh";
-const std::string RGB_COMMAND_NAME = "/usr/bin/analog_stick_led.sh";
+const std::string RGB_SERVICE_NAME = "/usr/bin/knulli-rgb-led-daemon";
+const std::string RGB_COMMAND_NAME = "/usr/bin/knulli-rgb-led";
 const std::string SEPARATOR = " ";
 const std::string START = "start clear";
 const std::string STOP = "stop";


### PR DESCRIPTION
**ATTENTION:** This does only work with corresponding distribution PR here: https://github.com/knulli-cfw/distribution/pull/256

* Range of speed/brightness is now 0-100
* Sliders now have steps of 5/100 or 10/255
* Re-enabled achievement option for TrimUI devices