### PR TITLE
Quick Resume Mode - Testing, Fixes, & Refactoring

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -28,6 +28,7 @@ set(ES_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveStateRepository.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SaveStateConfigFile.h    
 	${CMAKE_CURRENT_SOURCE_DIR}/src/CustomFeatures.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/QuickResume.h
 
     # GuiComponents    
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/ScraperSearchComponent.h    
@@ -140,7 +141,8 @@ set(ES_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveState.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveStateRepository.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SaveStateConfigFile.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/src/CustomFeatures.cpp	
+	${CMAKE_CURRENT_SOURCE_DIR}/src/CustomFeatures.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/QuickResume.cpp
 
     # GuiComponents    
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/ScraperSearchComponent.cpp	

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -700,7 +700,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	if (command.empty())
 		return false;
 
-	// KNULLI - QUICK RESUME MODE - logging will be cleaned up after testing >>>>>
+	// KNULLI - QUICK RESUME MODE >>>>>
 	bool quickResume = SystemConf::getInstance()->getBool("global.quickresume") == true;
 	std::string quickResumeCommand = getlaunchCommand(false);
 	std::string quickResumePath = getFullPath();
@@ -753,40 +753,20 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	if (!p2kConv.empty()) // delete .keys file if it has been converted from p2k
 		Utils::FileSystem::removeFile(p2kConv);
 
-	// KNULLI: QUICK RESUME MODE - logging will be cleaned up after testing >>>
-	std::string logMessage = "";
-	logMessage.append("\nnow exiting game. processing quick resume settings.");
+	Scripting::fireEvent("game-end");
+	
+	// KNULLI: QUICK RESUME MODE >>>>>
+	bool shutDownFlag = Utils::FileSystem::exists("/var/run/shutdown.flag");
 
-	if (!quickResume)
+	if (quickResume && !shutDownFlag)
 	{
-		// quick resume is not enabled, not preserving  batocera.conf settings
-		LOG(LogInfo) << "Quick resume not enabled. Ignoring global.bootgame settings in batoecera.conf.";
-		logMessage.append("\nQuick resume not enabled. Ignoring global.bootgame settings in batoecera.conf.");
-	}
-	else if (Utils::FileSystem::exists("/var/run/shutdown-ingame.flag"))
-	{
-		// exiting due to power event - preserving batocera.conf settings for global.bootgame command and path
-		LOG(LogInfo) << "Quick Resume enabled and shutting down in-game. Preserved global.bootgame settings in batocera.conf. ";
-		logMessage.append("\nQuick Resume enabled and shutting down in-game. Preserved global.bootgame settings in batocera.conf. ");
-	}
-	else
-	{
-		// exiting game normally, reset the batocera.conf settings for global.bootgame command and path
+		// exiting game normally, reset the batocera.conf settings for global.bootgame cmd, path
 		SystemConf::getInstance()->set("global.bootgame.path", "");
 		SystemConf::getInstance()->set("global.bootgame.cmd", "");
 		SystemConf::getInstance()->saveSystemConf();
-
-		// log the output
-		LOG(LogInfo) << "Quick resume enabled and not shutting down in-game. Cleared global.bootgame settings from batocera.conf. ";
-		logMessage.append("\nQuick resume enabled and not shutting down in-game. Cleared global.bootgame settings from batocera.conf. ");
 	}
+	// KNULLI - QUICK RESUME MODE <<<<<
 
-	// write out the debug log to assist with testing
-	Utils::FileSystem::writeAllText("/userdata/system/logs/quick-resume-testing.log", logMessage);
-	// KNULLI - QUICK RESUME MODE <<<
-
-	Scripting::fireEvent("game-end");
-	
 	if (!hideWindow && Settings::getInstance()->getBool("HideWindowFullReinit"))
 	{
 		ResourceManager::getInstance()->reloadAll();

--- a/es-app/src/QuickResume.cpp
+++ b/es-app/src/QuickResume.cpp
@@ -1,0 +1,61 @@
+#include "QuickResume.h"
+#include <SystemConf.h>
+#include "utils/FileSystemUtil.h"
+
+namespace QuickResume
+{    
+    const std::string shutdownFlag = "/var/run/shutdown.flag";
+
+    bool setQuickResume(std::string quickResumeCommand, std::string quickResumePath)
+    {
+        bool configSaved = false;
+
+        if (quickResumeEnabled())
+        {
+            if (!quickResumeCommand.empty() && !quickResumePath.empty())
+            {
+                SystemConf::getInstance()->set("global.bootgame.path", quickResumePath);
+                SystemConf::getInstance()->set("global.bootgame.cmd", quickResumeCommand);
+                configSaved = SystemConf::getInstance()->saveSystemConf();
+            }
+        }
+
+        return configSaved;
+    }
+
+    bool clearQuickResume()
+    {
+        bool configSaved = false;
+
+        if (quickResumeEnabled())
+        {
+            SystemConf::getInstance()->set("global.bootgame.path", "");
+            SystemConf::getInstance()->set("global.bootgame.cmd", "");
+            configSaved = SystemConf::getInstance()->saveSystemConf();
+        }
+
+        return configSaved;
+    }
+
+    bool postLaunchConditionalClean()
+    {
+        bool configSaved = false;
+
+        if (quickResumeEnabled() && !shutDownInProgress())
+        {
+            configSaved = clearQuickResume();
+        }
+
+        return configSaved;
+    }
+
+    bool shutDownInProgress()
+    {
+        return Utils::FileSystem::exists(shutdownFlag);
+    }
+
+    bool quickResumeEnabled()
+    {
+        return SystemConf::getInstance()->getBool("global.quickresume") == true;
+    }
+}

--- a/es-app/src/QuickResume.h
+++ b/es-app/src/QuickResume.h
@@ -1,0 +1,11 @@
+#include "SystemConf.h"
+#include "utils/FileSystemUtil.h"
+
+namespace QuickResume
+{
+    bool setQuickResume(std::string quickResumeCommand, std::string quickResumePath);
+    bool clearQuickResume();
+    bool postLaunchConditionalClean();
+    bool quickResumeEnabled();
+    bool shutDownInProgress();
+}

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -532,8 +532,8 @@ int main(int argc, char* argv[])
 
 #if !WIN32
 	if(enable_startup_game) {
-	    // Run boot game, before Window Create for linux
-	    launchStartupGame();
+	    	// Run boot game, before Window Create for linux
+		launchStartupGame();
 		postLaunchStartupGame();
 	}
 #endif

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -434,8 +434,21 @@ void launchStartupGame()
 	{
 		InputManager::getInstance()->init();
 		command = Utils::String::replace(command, "%CONTROLLERSCONFIG%", InputManager::getInstance()->configureEmulators());
-		Utils::Platform::ProcessStartInfo(command).run();		
+		Utils::Platform::ProcessStartInfo(command).run();
 	}	
+}
+
+void postLaunchStartupGame()
+{
+	bool shutdownFlag = Utils::FileSystem::exists("/var/run/shutdown.flag");
+	bool quickResumeEnabled = SystemConf::getInstance()->getBool("global.quickresume") == true;
+
+	if (!shutdownFlag && quickResumeEnabled)
+	{
+		SystemConf::getInstance()->set("global.bootgame.path", "");
+		SystemConf::getInstance()->set("global.bootgame.cmd", "");
+		SystemConf::getInstance()->saveSystemConf();
+	}
 }
 
 #include "utils/MathExpr.h"
@@ -519,8 +532,9 @@ int main(int argc, char* argv[])
 
 #if !WIN32
 	if(enable_startup_game) {
-	  // Run boot game, before Window Create for linux
-	  launchStartupGame();
+	    // Run boot game, before Window Create for linux
+	    launchStartupGame();
+		postLaunchStartupGame();
 	}
 #endif
 

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -41,6 +41,7 @@
 #include "Scripting.h"
 #include "watchers/WatchersManager.h"
 #include "HttpReq.h"
+#include "QuickResume.h"
 
 #ifdef WIN32
 #include <Windows.h>
@@ -435,20 +436,10 @@ void launchStartupGame()
 		InputManager::getInstance()->init();
 		command = Utils::String::replace(command, "%CONTROLLERSCONFIG%", InputManager::getInstance()->configureEmulators());
 		Utils::Platform::ProcessStartInfo(command).run();
+		// KNULLI - QUICK RESUME MODE >>>>>
+		QuickResume::postLaunchConditionalClean();
+		// KNULLI - QUICK RESUME MODE <<<<<
 	}	
-}
-
-void postLaunchStartupGame()
-{
-	bool shutdownFlag = Utils::FileSystem::exists("/var/run/shutdown.flag");
-	bool quickResumeEnabled = SystemConf::getInstance()->getBool("global.quickresume") == true;
-
-	if (!shutdownFlag && quickResumeEnabled)
-	{
-		SystemConf::getInstance()->set("global.bootgame.path", "");
-		SystemConf::getInstance()->set("global.bootgame.cmd", "");
-		SystemConf::getInstance()->saveSystemConf();
-	}
 }
 
 #include "utils/MathExpr.h"
@@ -534,7 +525,6 @@ int main(int argc, char* argv[])
 	if(enable_startup_game) {
 	    	// Run boot game, before Window Create for linux
 		launchStartupGame();
-		postLaunchStartupGame();
 	}
 #endif
 


### PR DESCRIPTION
Testing and bug fixes. Added `in-game.flag` for use by `knulli-shutdown` system script and the EmulationStation components that require it.