### PR TITLE
Lid close: device filtering fix.

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -701,7 +701,6 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		return false;
 
 	// KNULLI - QUICK RESUME MODE >>>>>
-	std::string logMessage;
 	bool quickResume = SystemConf::getInstance()->getBool("global.quickresume") == true;
 	std::string quickResumeCommand = getlaunchCommand(false);
 	std::string quickResumePath = getFullPath();
@@ -757,30 +756,15 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	Scripting::fireEvent("game-end");
 	
 	// KNULLI: QUICK RESUME MODE >>>>>
-	bool shuttingDown = Utils::FileSystem::exists("/var/run/shutdown.flag");
-	logMessage.append("Now exiting game. processing quick resume settings. shuttingDown is: " + shuttingDown);
+	bool shutDownFlag = Utils::FileSystem::exists("/var/run/shutdown.flag");
 
-	if (quickResume && !shuttingDown)
+	if (quickResume && !shutDownFlag)
 	{
-		// exiting game normally, reset the batocera.conf settings for global.bootgame command and path
+		// exiting game normally, reset the batocera.conf settings for global.bootgame cmd, path
 		SystemConf::getInstance()->set("global.bootgame.path", "");
 		SystemConf::getInstance()->set("global.bootgame.cmd", "");
 		SystemConf::getInstance()->saveSystemConf();
-
-		// log the output
-		LOG(LogInfo) << "Quick resume enabled and not shutting down (in-game). Cleared global.bootgame settings from batocera.conf.";
-		logMessage.append("Quick resume enabled and not shutting down (in-game). Cleared global.bootgame settings from batocera.conf.");
 	}
-	else
-	{
-		LOG(LogInfo) << "Preserved global.bootgame settings in batocera.conf.";
-		logMessage.append("Preserved global.bootgame settings in batocera.conf.");
-	}
-
-
-	// write out the debug log to assist with testing
-	std::string existingLog = Utils::FileSystem::readAllText(logFile).append("\n");
-	Utils::FileSystem::writeAllText(logFile, existingLog.append(logMessage));
 	// KNULLI - QUICK RESUME MODE <<<<<
 
 	if (!hideWindow && Settings::getInstance()->getBool("HideWindowFullReinit"))

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -757,8 +757,8 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	Scripting::fireEvent("game-end");
 	
 	// KNULLI: QUICK RESUME MODE >>>>>
-	logMessage.append("Now exiting game. processing quick resume settings.");
 	bool shuttingDown = Utils::FileSystem::exists("/var/run/shutdown.flag");
+	logMessage.append("Now exiting game. processing quick resume settings. shuttingDown is: " + shuttingDown);
 
 	if (quickResume && !shuttingDown)
 	{

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -760,19 +760,19 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 
 	std::string logFile = "/userdata/system/logs/quick-resume.log";
 	std::string logMessage = "";
-	logMessage.append("\nnow exiting game. processing quick resume settings.");
+	logMessage.append("Now exiting game. processing quick resume settings.");
 
 	if (!quickResume)
 	{
 		// quick resume is not enabled, not preserving  batocera.conf settings
 		LOG(LogInfo) << "Quick resume not enabled. Ignoring global.bootgame settings in batoecera.conf.";
-		logMessage.append("\nQuick resume not enabled. Ignoring global.bootgame settings in batoecera.conf.");
+		logMessage.append("Quick resume not enabled. Ignoring global.bootgame settings in batoecera.conf.");
 	}
 	else if (Utils::FileSystem::exists("/var/run/shutdown.flag"))
 	{
 		// exiting due to power event - preserving batocera.conf settings for global.bootgame command and path
-		LOG(LogInfo) << "Quick Resume enabled and shutting down in-game. Preserved global.bootgame settings in batocera.conf. ";
-		logMessage.append("\nQuick Resume enabled and shutting down in-game. Preserved global.bootgame settings in batocera.conf. ");
+		LOG(LogInfo) << "Quick Resume enabled and shutting down in-game. Preserved global.bootgame settings in batocera.conf.";
+		logMessage.append("Quick Resume enabled and shutting down in-game. Preserved global.bootgame settings in batocera.conf.");
 	}
 	else
 	{
@@ -782,8 +782,8 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		SystemConf::getInstance()->saveSystemConf();
 
 		// log the output
-		LOG(LogInfo) << "Quick resume enabled and not shutting down in-game. Cleared global.bootgame settings from batocera.conf. ";
-		logMessage.append("\nQuick resume enabled and not shutting down in-game. Cleared global.bootgame settings from batocera.conf. ");
+		LOG(LogInfo) << "Quick resume enabled and not shutting down in-game. Cleared global.bootgame settings from batocera.conf.";
+		logMessage.append("Quick resume enabled and not shutting down in-game. Cleared global.bootgame settings from batocera.conf.");
 	}
 
 	// write out the debug log to assist with testing

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -713,7 +713,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		SystemConf::getInstance()->saveSystemConf();
 	}
 
-	Utils::FileSystem:: writeAllText("/var/run/game_running.flag");
+	// Utils::FileSystem:: writeAllText("/var/run/game_running.flag");
 	// KNULLI - QUICK RESUME MODE <<<<<
 
 	AudioManager::getInstance()->deinit();
@@ -756,7 +756,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		Utils::FileSystem::removeFile(p2kConv);
 
 	// KNULLI: QUICK RESUME MODE - logging will be cleaned up after testing >>>
-	Utils::FileSystem::removeFile("/var/run/game_running.flag");
+	// Utils::FileSystem::removeFile("/var/run/game_running.flag");
 
 	std::string logFile = "/userdata/system/logs/quick-resume.log";
 	std::string logMessage = "";

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -712,6 +712,8 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		SystemConf::getInstance()->set("global.bootgame.cmd", quickResumeCommand);
 		SystemConf::getInstance()->saveSystemConf();
 	}
+
+	Utils::FileSystem:: writeAllText("/var/run/game_running.flag");
 	// KNULLI - QUICK RESUME MODE <<<<<
 
 	AudioManager::getInstance()->deinit();
@@ -754,6 +756,8 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		Utils::FileSystem::removeFile(p2kConv);
 
 	// KNULLI: QUICK RESUME MODE - logging will be cleaned up after testing >>>
+	Utils::FileSystem::removeFile("/var/run/game_running.flag");
+
 	std::string logFile = "/userdata/system/logs/quick-resume.log";
 	std::string logMessage = "";
 	logMessage.append("\nnow exiting game. processing quick resume settings.");
@@ -783,7 +787,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	}
 
 	// write out the debug log to assist with testing
-	std::string existingLog = Utils::FileSystem::readAllText(logFile).append("\n\n");
+	std::string existingLog = Utils::FileSystem::readAllText(logFile).append("\n");
 	Utils::FileSystem::writeAllText(logFile, existingLog.append(logMessage));
 	// KNULLI - QUICK RESUME MODE <<<
 

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -768,7 +768,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		LOG(LogInfo) << "Quick resume not enabled. Ignoring global.bootgame settings in batoecera.conf.";
 		logMessage.append("\nQuick resume not enabled. Ignoring global.bootgame settings in batoecera.conf.");
 	}
-	else if (Utils::FileSystem::exists("/var/run/shutdown-ingame.flag"))
+	else if (Utils::FileSystem::exists("/var/run/shutdown.flag"))
 	{
 		// exiting due to power event - preserving batocera.conf settings for global.bootgame command and path
 		LOG(LogInfo) << "Quick Resume enabled and shutting down in-game. Preserved global.bootgame settings in batocera.conf. ";

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -37,7 +37,7 @@
 using namespace Utils::Platform;
 
 // KNULLI - QUICK RESUME MODE - logging will be cleaned up after testing >>>>>
-const std::string logFile = "/userdata/system/logs/quick-resume.log";
+// const std::string logFile = "/userdata/system/logs/quick-resume.log";
 // KNULLI - QUICK RESUME MODE <<<<<
 
 static std::map<std::string, std::function<BindableProperty(FileData*)>> properties =
@@ -754,6 +754,7 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 		Utils::FileSystem::removeFile(p2kConv);
 
 	// KNULLI: QUICK RESUME MODE - logging will be cleaned up after testing >>>
+	std::string logFile = "/userdata/system/logs/quick-resume.log";
 	std::string logMessage = "";
 	logMessage.append("\nnow exiting game. processing quick resume settings.");
 
@@ -782,7 +783,8 @@ bool FileData::launchGame(Window* window, LaunchGameOptions options)
 	}
 
 	// write out the debug log to assist with testing
-	Utils::FileSystem::writeAllText("/userdata/system/logs/quick-resume-testing.log", logMessage);
+	std::string existingLog = Utils::FileSystem::readAllText(logFile).append("\n\n");
+	Utils::FileSystem::writeAllText(logFile, existingLog.append(logMessage));
 	// KNULLI - QUICK RESUME MODE <<<
 
 	Scripting::fireEvent("game-end");

--- a/es-app/src/guis/knulli/GuiPowerManagementSettings.cpp
+++ b/es-app/src/guis/knulli/GuiPowerManagementSettings.cpp
@@ -16,7 +16,7 @@
 #include "utils/Platform.h"
 #include "BoardCheck.h"
 
-const std::vector<std::string> SUPPORTED_LID_BOARDS = {"rg40xx-sp"};
+const std::vector<std::string> SUPPORTED_LID_BOARDS = {"rg35xx-sp"};
 
 GuiPowerManagementSettings::GuiPowerManagementSettings(Window* window) : GuiSettings(window, _("POWER MANAGEMENT").c_str())
 {

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -531,7 +531,7 @@ int main(int argc, char* argv[])
 	if(enable_startup_game) {
 	    // Run boot game, before Window Create for linux
 	    launchStartupGame();
-		postLauchStartupGame();
+		postLaunchStartupGame();
 	}
 #endif
 

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -531,7 +531,7 @@ int main(int argc, char* argv[])
 	if(enable_startup_game) {
 	    // Run boot game, before Window Create for linux
 	    launchStartupGame();
-		postLauchStatupGame();
+		postLauchStartupGame();
 	}
 #endif
 

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -434,8 +434,18 @@ void launchStartupGame()
 	{
 		InputManager::getInstance()->init();
 		command = Utils::String::replace(command, "%CONTROLLERSCONFIG%", InputManager::getInstance()->configureEmulators());
-		Utils::Platform::ProcessStartInfo(command).run();		
+		Utils::Platform::ProcessStartInfo(command).run();
 	}	
+}
+
+void postLaunchStartupGame()
+{
+	if (SystemConf::getInstance()->getBool("global.quickresume") == true)
+	{
+		SystemConf::getInstance()->set("global.bootgame.path", "");
+		SystemConf::getInstance()->set("global.bootgame.cmd", "");
+		SystemConf::getInstance()->saveSystemConf();
+	}
 }
 
 #include "utils/MathExpr.h"
@@ -519,8 +529,9 @@ int main(int argc, char* argv[])
 
 #if !WIN32
 	if(enable_startup_game) {
-	  // Run boot game, before Window Create for linux
-	  launchStartupGame();
+	    // Run boot game, before Window Create for linux
+	    launchStartupGame();
+		postLauchStatupGame();
 	}
 #endif
 

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -440,7 +440,10 @@ void launchStartupGame()
 
 void postLaunchStartupGame()
 {
-	if (SystemConf::getInstance()->getBool("global.quickresume") == true)
+	bool shutdownFlag = Utils::FileSystem::exists("/var/run/shutdown.flag");
+	bool quickResumeEnabled = SystemConf::getInstance()->getBool("global.quickresume") == true;
+
+	if (!shutdownFlag && quickResumeEnabled)
 	{
 		SystemConf::getInstance()->set("global.bootgame.path", "");
 		SystemConf::getInstance()->set("global.bootgame.cmd", "");


### PR DESCRIPTION
Fixed a small bug where `SUPPORTED_LID_BOARDS` was set to `rg40xx-sp`. Have updated to `rg35xx-sp`, which restores the menu item.