### PR TITLE
lid close preference in device settings menu fix

### DIFF
--- a/es-app/src/guis/knulli/GuiPowerManagementSettings.cpp
+++ b/es-app/src/guis/knulli/GuiPowerManagementSettings.cpp
@@ -16,7 +16,7 @@
 #include "utils/Platform.h"
 #include "BoardCheck.h"
 
-const std::vector<std::string> SUPPORTED_LID_BOARDS = {"rg40xx-sp"};
+const std::vector<std::string> SUPPORTED_LID_BOARDS = {"rg35xx-sp"};
 
 GuiPowerManagementSettings::GuiPowerManagementSettings(Window* window) : GuiSettings(window, _("POWER MANAGEMENT").c_str())
 {


### PR DESCRIPTION
Changed the value of `SUPPORTED_LID_BOARDS` FROM `rg40xx-sp` to `rg35xx-sp` in device settings configuration menu.