### PR TITLE
Introduced KNULLI flag, hid some irrelevant menu options, added RGB sanity check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(BCM "BCM host" OFF)
 
 option(BATOCERA "Set to ON to enable BATOCERA specific code" OFF)
 option(RETROBAT "Set to ON to enable RETROBAT specific code" OFF)
+option(KNULLI "Set to ON to enable KNULLI specific code" OFF)
 
 option(ENABLE_FILEMANAGER "Set to ON to enable f1 shortcut for filesystem" OFF)
 option(DISABLE_KODI "Set to ON to disable kodi in menu" OFF)
@@ -95,6 +96,11 @@ endif()
 if(RETROBAT)
   MESSAGE("Retrobat build")
   add_definitions(-DRETROBAT)
+endif()
+
+if(KNULLI)
+  MESSAGE("Knulli build")
+  add_definitions(-DKNULLI)
 endif()
 
 # disable kodi menu

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -199,8 +199,9 @@ GuiMenu::GuiMenu(Window *window, bool animate) : GuiComponent(window), mMenu(win
 			ApiSystem::getInstance()->isScriptingSupported(ApiSystem::UPGRADE))
 			addEntry(_("UPDATES & DOWNLOADS"), true, [this] { openUpdatesSettings(); }, "iconUpdates");
 
-		// Tools (Knulli-specific)
+#ifdef KNULLI
 		addEntry(_("DEVICE SETTINGS"), true, [this] { openDeviceSettings(); }, "iconSystem");
+#endif
 		addEntry(_("SYSTEM SETTINGS").c_str(), true, [this] { openSystemSettings(); }, "iconSystem");
 	}
 	else
@@ -1238,6 +1239,7 @@ void GuiMenu::openUpdatesSettings()
 		});
 	}
 
+#ifndef KNULLI
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::UPGRADE))
 	{
 		updateGui->addGroup(_("SOFTWARE UPDATES"));
@@ -1289,7 +1291,7 @@ void GuiMenu::openUpdatesSettings()
 			}
 		});
 	}
-
+#endif
 	mWindow->pushGui(updateGui);
 }
 
@@ -1673,6 +1675,7 @@ void GuiMenu::openSystemSettings()
 	  }
 	});
 
+#ifndef KNULLI
 	// splash
 	auto optionsSplash = std::make_shared<OptionListComponent<std::string> >(mWindow, _("BOOT SPLASH"), false);
 
@@ -1714,6 +1717,7 @@ void GuiMenu::openSystemSettings()
 	    SystemConf::getInstance()->saveSystemConf();
 	  }
 	});
+#endif
 #else
 	if (!ApiSystem::getInstance()->isScriptingSupported(ApiSystem::GAMESETTINGS))
 	{
@@ -1840,11 +1844,15 @@ void GuiMenu::openSystemSettings()
 	}
 
 #ifdef BATOCERA
+#ifndef KNULLI
 	s->addEntry(_("DMD"), true, [this] { openDmdSettings(); });
+#endif
 #endif
 
 #ifdef BATOCERA
+#ifndef KNULLI
         s->addEntry(_("MULTISCREENS"), true, [this] { openMultiScreensSettings(); });
+#endif
 #endif
 
 #ifdef BATOCERA

--- a/es-app/src/guis/knulli/GuiRgbSettings.cpp
+++ b/es-app/src/guis/knulli/GuiRgbSettings.cpp
@@ -116,17 +116,25 @@ std::shared_ptr<OptionListComponent<std::string>> GuiRgbSettings::createModeOpti
     optionsLedMode->add(_("NONE"), "0", selectedLedMode == "0");
     if (isH700 || isA133) {
         optionsLedMode->add(_("STATIC"), "1", selectedLedMode == "1");
+    } else if (selectedLedMode == "1") {
+        selectedLedMode = DEFAULT_LED_MODE;
     }
     if (isH700) {
         optionsLedMode->add(_("BREATHING (FAST)"), "2", selectedLedMode == "2");
+    } else if (selectedLedMode == "2") {
+        selectedLedMode = DEFAULT_LED_MODE;
     }
     if (isH700 || isA133) {
         optionsLedMode->add(_("BREATHING (MEDIUM)"), "3", selectedLedMode == "3");
+    } else if (selectedLedMode == "3") {
+        selectedLedMode = DEFAULT_LED_MODE;
     }
     if (isH700) {
         optionsLedMode->add(_("BREATHING (SLOW)"), "4", selectedLedMode == "4");
         optionsLedMode->add(_("SINGLE RAINBOW"), "5", selectedLedMode == "5");
         optionsLedMode->add(_("MULTI RAINBOW"), "6", selectedLedMode == "6");
+    } else  if (selectedLedMode == "4" || selectedLedMode == "5" || selectedLedMode == "6") {
+        selectedLedMode = DEFAULT_LED_MODE;
     }
 
     addWithDescription(_("MODE"), _("Set the default LED animation. (Not all of the settings below are applicable to every mode.)"), optionsLedMode);


### PR DESCRIPTION
I propose to decline PR https://github.com/knulli-cfw/batocera-emulationstation/pull/23 since commenting out code instead of disabling it properly is a bad idea. I introduced a new `KNULLI` flag that can be checked for with `ifdef` and `ifndef` and used this mechanic to hide a couple of menus/options, including the ones proposed in PR https://github.com/knulli-cfw/batocera-emulationstation/pull/23.

Additionally, I added an RGB settings sanity check because some user ran into an issue with the menu not opening due to a mode being configured in `batocera.conf` that wasn't available any more for their device.

Be aware of the corresponding PR in Knulli distribution: https://github.com/knulli-cfw/distribution/pull/277