### PR TITLE
[Screensaver] Add Date Time display

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -26,7 +26,8 @@
 #include "Paths.h"
 #include "ApiSystem.h"
 
-#define FADE_TIME 			500
+#define FADE_TIME					(500)
+#define DATE_TIME_UPDATE_INTERVAL	(100)
 
 SystemScreenSaver::SystemScreenSaver(Window* window) :
 	mVideoScreensaver(NULL),
@@ -524,6 +525,39 @@ GameScreenSaverBase::GameScreenSaverBase(Window* window) : GuiComponent(window),
 	mMarquee = nullptr;
 	mLabelGame = nullptr;
 	mLabelSystem = nullptr;
+	mLabelDate = nullptr;
+	mLabelTime = nullptr;
+	mDateTimeUpdateAccumulator = 0;
+	mDateTimeLastUpdate = 0;
+
+	if (Settings::getInstance()->getBool("ScreenSaverDateTime"))
+	{
+		auto ph = ThemeData::getMenuTheme()->Text.font->getPath();
+		auto sz = mViewport.h / 16.f;
+		auto margin = sz / 2.f;
+		auto font = Font::get(sz, ph);
+		int fh = font->getLetterHeight();
+
+		mLabelDate = new TextComponent(mWindow);
+		mLabelDate->setPosition(mViewport.x + margin, mViewport.y + margin);
+		mLabelDate->setSize(mViewport.w, sz * 0.66);
+		mLabelDate->setHorizontalAlignment(ALIGN_LEFT);
+		mLabelDate->setVerticalAlignment(ALIGN_CENTER);
+		mLabelDate->setColor(0xD0D0D0FF);
+		mLabelDate->setGlowColor(0x00000060);
+		mLabelDate->setGlowSize(2);
+		mLabelDate->setFont(ph, sz * 0.66);
+
+		mLabelTime = new TextComponent(mWindow);
+		mLabelTime->setPosition(mViewport.x + margin, mViewport.y + margin + mLabelDate->getSize().y() * 1.3f);
+		mLabelTime->setSize(mViewport.w, fh);
+		mLabelTime->setHorizontalAlignment(ALIGN_LEFT);
+		mLabelTime->setVerticalAlignment(ALIGN_CENTER);
+		mLabelTime->setColor(0xFFFFFFFF);
+		mLabelTime->setGlowColor(0x00000040);
+		mLabelTime->setGlowSize(3);
+		mLabelTime->setFont(font);
+	}
 }
 
 GameScreenSaverBase::~GameScreenSaverBase()
@@ -550,6 +584,18 @@ GameScreenSaverBase::~GameScreenSaverBase()
 	{
 		delete mLabelSystem;
 		mLabelSystem = nullptr;
+	}
+
+	if (mLabelDate != nullptr)
+	{
+		delete mLabelDate;
+		mLabelDate = nullptr;
+	}
+
+	if (mLabelTime != nullptr)
+	{
+		delete mLabelTime;
+		mLabelTime = nullptr;
 	}
 }
 
@@ -766,6 +812,66 @@ void GameScreenSaverBase::render(const Transform4x4f& transform)
 		mDecoration->setOpacity(mOpacity);
 		mDecoration->render(transform);
 	}
+
+	if (mLabelDate)
+	{
+		mLabelDate->setOpacity(255);
+		mLabelDate->render(transform);
+	}
+
+	if (mLabelTime)
+	{
+		mLabelTime->setOpacity(255);
+		mLabelTime->render(transform);
+	}
+}
+
+void GameScreenSaverBase::update(int deltaTime)
+{
+	if (Settings::getInstance()->getBool("ScreenSaverDateTime"))
+	{
+		mDateTimeUpdateAccumulator += deltaTime;
+		if (mDateTimeUpdateAccumulator >= DATE_TIME_UPDATE_INTERVAL)
+		{
+			mDateTimeUpdateAccumulator -= DATE_TIME_UPDATE_INTERVAL;
+
+			time_t now = time(NULL);
+			if (now != mDateTimeLastUpdate)
+			{
+				mDateTimeLastUpdate = now;
+
+				struct tm* timeinfo = localtime(&now);
+
+				const std::string& dateFormat = Settings::getInstance()->getString("ScreenSaverDateFormat");
+				const std::string& timeFormat = Settings::getInstance()->getString("ScreenSaverTimeFormat");
+				const std::string* dateFormatPtr = &dateFormat;
+
+				std::string modifiedDateFormat;
+				std::string language = SystemConf::getInstance()->get("system.language");
+				if (language == "ko_KR")	// fix Korean string
+				{
+					if (dateFormat == "%A, %B %d")
+						modifiedDateFormat = std::string("%A, %B %d일");
+					else if (dateFormat == "%b %d, %Y")
+						modifiedDateFormat = std::string("%b %d일, %Y년");
+				}
+				if (!modifiedDateFormat.empty()) {
+					dateFormatPtr = &modifiedDateFormat;
+				}
+
+				char dateBuffer[64];
+				char timeBuffer[64];
+				strftime(dateBuffer, sizeof(dateBuffer), dateFormatPtr->c_str(), timeinfo);
+				strftime(timeBuffer, sizeof(timeBuffer), timeFormat.c_str(), timeinfo);
+
+				if (mLabelDate)
+					mLabelDate->setText(std::string(dateBuffer));
+
+				if (mLabelTime)
+					mLabelTime->setText(std::string(timeBuffer));
+			}
+		}
+	}
 }
 
 void GameScreenSaverBase::setOpacity(unsigned char opacity)
@@ -932,13 +1038,25 @@ void VideoScreenSaver::render(const Transform4x4f& transform)
 		mDecoration->render(transform);		
 	}
 
+	if (mLabelDate)
+	{
+		mLabelDate->setOpacity(255);
+		mLabelDate->render(transform);
+	}
+
+	if (mLabelTime)
+	{
+		mLabelTime->setOpacity(255);
+		mLabelTime->render(transform);
+	}
+
 	if (Settings::DebugImage())
 		Renderer::drawRect(mViewport.x, mViewport.y, mViewport.w, mViewport.h, 0xFFFF0090, 0xFFFF0090);
 }
 
 void VideoScreenSaver::update(int deltaTime)
 {
-	GameScreenSaverBase::update(deltaTime);
+	GameScreenSaverBase::update(deltaTime); 
 
 	if (mVideo)
 	{

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -20,6 +20,7 @@ public:
 	virtual void setGame(FileData* mCurrentGame);
 
 	void render(const Transform4x4f& transform) override;
+	void update(int deltaTime) override;
 
 	void setOpacity(unsigned char opacity) override;
 
@@ -27,10 +28,15 @@ protected:
 	ImageComponent*		mMarquee;
 	TextComponent*		mLabelGame;
 	TextComponent*		mLabelSystem;
+	TextComponent*		mLabelDate;
+	TextComponent*		mLabelTime;
 
 	ImageComponent*		mDecoration;
 
 	Renderer::Rect		mViewport;
+
+	int 				mDateTimeUpdateAccumulator;
+	time_t				mDateTimeLastUpdate;
 };
 
 class ImageScreenSaver : public GameScreenSaverBase

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
@@ -116,6 +116,38 @@ void GuiGeneralScreensaverOptions::addVideoScreensaverOptions(int selectItem)
 	addWithLabel(_("SHOW GAME INFO"), ss_info);
 	addSaveFunc([ss_info, this] { Settings::getInstance()->setString("ScreenSaverGameInfo", ss_info->getSelected()); });
 
+	// SHOW DATE TIME
+	{
+		bool showDateTime = Settings::getInstance()->getBool("ScreenSaverDateTime");
+
+		auto datetime_screensaver = std::make_shared<SwitchComponent>(mWindow);
+		datetime_screensaver->setState(showDateTime);
+		addWithLabel(_("SHOW DATE TIME"), datetime_screensaver, selectItem == 5);
+
+		datetime_screensaver->setOnChangedCallback([this, datetime_screensaver]()
+			{
+				if (Settings::getInstance()->setBool("ScreenSaverDateTime", datetime_screensaver->getState()))
+				{
+					Window* pw = mWindow;
+					delete this;
+					pw->pushGui(new GuiGeneralScreensaverOptions(pw, 5));
+				}
+			});
+
+		if (showDateTime)
+		{
+			auto sss_date_format = std::make_shared< OptionListComponent<std::string> >(mWindow, _("DATE FORMAT"), false);
+			sss_date_format->addRange({ "%Y-%m-%d", "%d-%m-%Y", "%A, %B %d", "%b %d, %Y" }, Settings::getInstance()->getString("ScreenSaverDateFormat"));
+			addWithLabel(_("DATE FORMAT"), sss_date_format);
+			addSaveFunc([sss_date_format] { Settings::getInstance()->setString("ScreenSaverDateFormat", sss_date_format->getSelected()); });
+
+			auto sss_time_format = std::make_shared< OptionListComponent<std::string> >(mWindow, _("TIME FORMAT"), false);
+			sss_time_format->addRange({ "%H:%M:%S", "%I:%M %p", "%p %I:%M" }, Settings::getInstance()->getString("ScreenSaverTimeFormat"));
+			addWithLabel(_("TIME FORMAT"), sss_time_format);
+			addSaveFunc([sss_time_format] { Settings::getInstance()->setString("ScreenSaverTimeFormat", sss_time_format->getSelected()); });
+		}
+	}
+
 	bool advancedOptions = true;
 
 #ifdef _RPI_
@@ -206,6 +238,38 @@ void GuiGeneralScreensaverOptions::addSlideShowScreensaverOptions(int selectItem
 	ss_controls->setState(Settings::getInstance()->getBool("SlideshowScreenSaverGameName"));
 	addWithLabel(_("SHOW GAME INFO"), ss_controls);
 	addSaveFunc([ss_controls] { Settings::getInstance()->setBool("SlideshowScreenSaverGameName", ss_controls->getState()); });
+
+	// SHOW DATE TIME
+	{
+		bool showDateTime = Settings::getInstance()->getBool("ScreenSaverDateTime");
+
+		auto datetime_screensaver = std::make_shared<SwitchComponent>(mWindow);
+		datetime_screensaver->setState(showDateTime);
+		addWithLabel(_("SHOW DATE TIME"), datetime_screensaver, selectItem == 6);
+
+		datetime_screensaver->setOnChangedCallback([this, datetime_screensaver]()
+			{
+				if (Settings::getInstance()->setBool("ScreenSaverDateTime", datetime_screensaver->getState()))
+				{
+					Window* pw = mWindow;
+					delete this;
+					pw->pushGui(new GuiGeneralScreensaverOptions(pw, 6));
+				}
+			});
+
+		if (showDateTime)
+		{
+			auto sss_date_format = std::make_shared< OptionListComponent<std::string> >(mWindow, _("DATE FORMAT"), false);
+			sss_date_format->addRange({ "%Y-%m-%d", "%d-%m-%Y", "%A, %B %d", "%b %d, %Y"}, Settings::getInstance()->getString("ScreenSaverDateFormat"));
+			addWithLabel(_("DATE FORMAT"), sss_date_format);
+			addSaveFunc([sss_date_format] { Settings::getInstance()->setString("ScreenSaverDateFormat", sss_date_format->getSelected()); });
+
+			auto sss_time_format = std::make_shared< OptionListComponent<std::string> >(mWindow, _("TIME FORMAT"), false);
+			sss_time_format->addRange({ "%H:%M:%S", "%I:%M %p", "%p %I:%M"}, Settings::getInstance()->getString("ScreenSaverTimeFormat"));
+			addWithLabel(_("TIME FORMAT"), sss_time_format);
+			addSaveFunc([sss_time_format] { Settings::getInstance()->setString("ScreenSaverTimeFormat", sss_time_format->getSelected()); });
+		}
+	}
 
 	auto marquee_screensaver = std::make_shared<SwitchComponent>(mWindow);
 	marquee_screensaver->setState(Settings::getInstance()->getBool("ScreenSaverMarquee"));

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -223,7 +223,10 @@ void Settings::setDefaults()
 	mStringMap["ScrapperLogoSrc"] = "wheel";
 	mBoolMap["ScrapeVideos"] = false;
 	mBoolMap["ScrapeShortTitle"] = false;
-	
+
+	mBoolMap["ScreenSaverDateTime"] = false;
+	mStringMap["ScreenSaverDateFormat"] = "%Y-%m-%d";
+	mStringMap["ScreenSaverTimeFormat"] = "%H:%M:%S";
 	mBoolMap["ScreenSaverMarquee"] = true;
 	mBoolMap["ScreenSaverControls"] = false;
 	mStringMap["ScreenSaverGameInfo"] = "never";


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6f52ebec-9256-4aba-8338-da293752f082)
![image](https://github.com/user-attachments/assets/e0be5fd6-833a-45cc-a412-121ffafa1845)

- Added SHOW DATE TIME option to toggle date and time display.
- Select the display format using DATE FORMAT and TIME FORMAT options.
- This feature works with both RANDOM VIDEO and SLIDESHOW modes.

from https://github.com/batocera-linux/batocera-emulationstation/pull/1844
