### PR TITLE
Silence warnings

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1426,6 +1426,8 @@ bool ApiSystem::getLED(int& red, int& green, int& blue)
 
         return true;
     }
+
+	return false;
 }
 
 void ApiSystem::getLEDColours(int& red, int& green, int& blue)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -84,6 +84,7 @@
 #define fake_gettext_cpu_frequency _("Cpu max frequency")
 #define fake_gettext_cpu_feature  _("Cpu feature")
 
+/* This appears to be a typo.
 #define fake_gettext_cpu_feature  _("Available Memory")
 #define fake_gettext_cpu_feature  _("Display Resolution")
 #define fake_gettext_cpu_feature  _("Display Refresh Rate")
@@ -95,6 +96,7 @@
 #define fake_gettext_cpu_feature  _("Network IP Address")
 #define fake_gettext_cpu_feature  _("UEFI Boot")
 #define fake_gettext_cpu_feature  _("Secure Boot")
+*/
 
 #define fake_gettext_simple_bilinear_simple	pgettext("game_options", "SHARP-BILINEAR-SIMPLE")
 #define fake_gettext_scanlines				pgettext("game_options", "SCANLINES")

--- a/es-app/src/guis/knulli/GuiPowerManagementSettings.cpp
+++ b/es-app/src/guis/knulli/GuiPowerManagementSettings.cpp
@@ -100,7 +100,7 @@ GuiPowerManagementSettings::GuiPowerManagementSettings(Window* window) : GuiSett
 		addWithLabel(_("LID CLOSE MODE"), optionsLidCloseMode);
 	}
 
-	addSaveFunc([this, optionsBatterySaveMode, sliderBatterySaverTime, optionsBatterySaveExtendedMode, sliderBatterySaverExtendedTime, aggressiveBatterySaveMode, optionsLidCloseMode, this]
+	addSaveFunc([this, optionsBatterySaveMode, sliderBatterySaverTime, optionsBatterySaveExtendedMode, sliderBatterySaverExtendedTime, aggressiveBatterySaveMode, optionsLidCloseMode]
 	{
 		int newBatterySaverTimeSeconds = (int)Math::round(sliderBatterySaverTime->getValue()*60.f);
 		int newBatterySaverExtendedTimeSeconds = (int)Math::round(sliderBatterySaverExtendedTime->getValue()*60.f);

--- a/es-app/src/guis/knulli/GuiRgbSettings.cpp
+++ b/es-app/src/guis/knulli/GuiRgbSettings.cpp
@@ -195,7 +195,7 @@ std::array<float, 3> GuiRgbSettings::getRgbValues()
     int green = std::stoi(rgbValues[1]);
     int blue = std::stoi(rgbValues[2]);
 
-    return {red, green, blue};
+    return { static_cast<float>(red), static_cast<float>(green), static_cast<float>(blue) };
 }
 
 // Concatenates the RGB values and stores them in batocera.conf.

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -200,7 +200,7 @@ void HttpReq::performRequest(const std::string& url, HttpReqOptions* options)
 	}
 
 	//set curl restrict redirect protocols
-	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS); 
+	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
 	if(err != CURLE_OK)
 	{
 		mStatus = REQ_IO_ERROR;

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -783,7 +783,14 @@ void VideoVlcComponent::startVideo()
 
 			unsigned track_count;
 			// Get the media metadata so we can find the aspect ratio
+#ifdef WIN32
+			// It looks like an older version of the library is being used on Windows.
 			libvlc_media_parse(mMedia);
+#else
+			libvlc_media_parse_with_options(mMedia, libvlc_media_parse_local, 0);
+			while (libvlc_media_get_parsed_status(mMedia) != libvlc_media_parsed_status_done)
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
+#endif
 			libvlc_media_track_t** tracks;
 			track_count = libvlc_media_tracks_get(mMedia, &tracks);
 			for (unsigned track = 0; track < track_count; ++track)

--- a/es-core/src/components/WebImageComponent.cpp
+++ b/es-core/src/components/WebImageComponent.cpp
@@ -21,14 +21,14 @@ public:
 		const std::string prot_end("://");
 		std::string::const_iterator prot_i = search(url_s.begin(), url_s.end(), prot_end.begin(), prot_end.end());
 		ret.protocol.reserve(distance(url_s.begin(), prot_i));
-		transform(url_s.begin(), prot_i, back_inserter(ret.protocol), ptr_fun<int, int>(tolower));
+		std::transform(url_s.begin(), prot_i, std::back_inserter(ret.protocol), [](unsigned char c) { return std::tolower(c); });
 		if (prot_i == url_s.end())
 			return ret;
 
 		advance(prot_i, prot_end.length());
 		string::const_iterator path_i = find(prot_i, url_s.end(), '/');
 		ret.host.reserve(distance(prot_i, path_i));
-		transform(prot_i, path_i, back_inserter(ret.host), ptr_fun<int, int>(tolower)); // host is icase
+		std::transform(prot_i, path_i, std::back_inserter(ret.host), [](unsigned char c) { return std::tolower(c); }); // host is icase
 		string::const_iterator query_i = find(path_i, url_s.end(), '?');
 		ret.path.assign(path_i, query_i);
 		if (query_i != url_s.end())

--- a/external/id3v2lib/src/header.c
+++ b/external/id3v2lib/src/header.c
@@ -44,7 +44,14 @@ ID3v2_header* get_tag_header(const char* file_name)
         return NULL;
     }
 
-    fread(buffer, ID3_HEADER, 1, file);
+    size_t bytesRead = fread(buffer, ID3_HEADER, 1, file);
+    if (bytesRead != 1)
+    {
+        perror("Error reading file");
+        fclose(file);
+        return NULL;
+    }
+
     fclose(file);
     return get_tag_header_with_buffer(buffer, ID3_HEADER);
 }

--- a/external/id3v2lib/src/id3v2lib.c
+++ b/external/id3v2lib/src/id3v2lib.c
@@ -43,7 +43,14 @@ ID3v2_tag* load_tag(const char* file_name)
         return NULL;
     }
     //fseek(file, 10, SEEK_SET);
-    fread(buffer, header_size+10, 1, file);
+    size_t bytesRead = fread(buffer, header_size+10, 1, file);
+    if (bytesRead != 1)
+    {
+        perror("Error reading file");
+        fclose(file);
+        return NULL;
+    }
+
     fclose(file);
 
 
@@ -537,6 +544,12 @@ void tag_set_composer(char* composer, char encoding, ID3v2_tag* tag)
 void tag_set_album_cover(const char* filename, ID3v2_tag* tag)
 {
     FILE* album_cover = fopen(filename, "rb");
+    if (album_cover == NULL)
+    {
+        perror("Error opening file");
+        return;
+    }
+
     char *album_cover_bytes;
     int image_size;
     char *mimetype;
@@ -545,8 +558,22 @@ void tag_set_album_cover(const char* filename, ID3v2_tag* tag)
     image_size = (int) ftell(album_cover);
     fseek(album_cover, 0, SEEK_SET);
 
-    album_cover_bytes = (char*) malloc(image_size * sizeof(char));
-    fread(album_cover_bytes, 1, image_size, album_cover);
+    album_cover_bytes = (char*)malloc(image_size);
+    if (album_cover_bytes == NULL)
+    {
+        perror("Memory allocation failed");
+        fclose(album_cover);
+        return;
+    }
+
+    size_t bytesRead = fread(album_cover_bytes, 1, image_size, album_cover);
+    if (bytesRead != image_size)
+    {
+        perror("Error reading file");
+        free(album_cover_bytes);
+        fclose(album_cover);
+        return;
+    }
 
     fclose(album_cover);
 

--- a/external/libcheevos/cheevos.cpp
+++ b/external/libcheevos/cheevos.cpp
@@ -47,7 +47,7 @@ void rc_hash_handle_file_close(void* file_handle)
 	CHEEVOS_FREE(file_handle);
 }
 
-typedef struct cdreader_trackinfo
+struct cdreader_trackinfo
 {
 	cdreader_trackinfo(bool isChd, void* pointer) { chd = isChd; ptr = pointer; }
 


### PR DESCRIPTION
- Resolved the following warnings  
```
external/id3v2lib/src/header.c:47:5: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
external/id3v2lib/src/id3v2lib.c:46:5: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
external/id3v2lib/src/id3v2lib.c:549:5: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
external/libcheevos/cheevos.cpp:50:1: warning: ‘typedef’ was ignored in this declaration
es-core/src/HttpReq.cpp:203:41: warning: ‘CURLOPT_REDIR_PROTOCOLS’ is deprecated: since 7.85.0. Use CURLOPT_REDIR_PROTOCOLS_STR [-Wdeprecated-declarations]
es-core/src/components/VideoVlcComponent.cpp:786:43: warning: ‘void libvlc_media_parse(libvlc_media_t*)’ is deprecated [-Wdeprecated-declarations]
es-core/src/components/WebImageComponent.cpp:24:96: warning: ‘std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = int; _Result = int]’ is deprecated: use 'std::function' instead [-Wdeprecated-declarations]
es-core/src/components/WebImageComponent.cpp:31:85: warning: ‘std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = int; _Result = int]’ is deprecated: use 'std::function' instead [-Wdeprecated-declarations]
es-app/src/guis/GuiMenu.cpp:86: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:87: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:88: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:89: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:90: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:91: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:92: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:93: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:94: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:95: warning: "fake_gettext_cpu_feature" redefined
es-app/src/guis/GuiMenu.cpp:96: warning: "fake_gettext_cpu_feature" redefined
es-app/src/ApiSystem.cpp:1430:1: warning: control reaches end of non-void function [-Wreturn-type]
```
- Tested video screensaver playback (id3v2lib, videovlc) and NetPlay lobby call (HTTP), no issues found  

from https://github.com/batocera-linux/batocera-emulationstation/pull/1863