### PR TITLE
Fontface Artifact Fix

### DIFF
--- a/es-core/src/renderers/Renderer_GLES20.cpp
+++ b/es-core/src/renderers/Renderer_GLES20.cpp
@@ -671,40 +671,38 @@ namespace Renderer
 		// Regular GL_ALPHA textures are black + alpha in shaders
 		// Create a GL_LUMINANCE_ALPHA texture instead so its white + alpha
 		
-		if (type == GL_LUMINANCE_ALPHA && _data != nullptr)
+		if (type == GL_LUMINANCE_ALPHA)
 		{
-			uint8_t* a_data  = (uint8_t*)_data;
 			uint8_t* la_data = new uint8_t[_width * _height * 2];
-			memset(la_data, 255, _width * _height * 2);
-			if (a_data)
+						
+			if (_data == nullptr)
+				memset(la_data, 0, _width * _height * 2);
+			else
 			{
-				for(uint32_t i=0; i<(_width * _height); ++i)
+				uint8_t* a_data = (uint8_t*)_data;
+				for (uint32_t i = 0; i < (_width * _height); ++i)
 					la_data[(i * 2) + 1] = a_data[i];
 			}
 
-		//	while (glGetError() != GL_NO_ERROR);
-
 			glTexImage2D(GL_TEXTURE_2D, 0, type, _width, _height, 0, type, GL_UNSIGNED_BYTE, la_data);
 			delete[] la_data;
-
-			if (glGetError() != GL_NO_ERROR)
-			{
-				LOG(LogError) << "CreateTexture error: glTexImage2D failed";
-				destroyTexture(texture);
-				return 0;
-			}
+		}
+		else if (_data == nullptr)
+		{
+			// Seems required with some video cards or the texture bytes aren't blank
+			uint8_t* la_data = new uint8_t[_width * _height * 4];
+			memset(la_data, 0, _width * _height * 4);
+			glTexImage2D(GL_TEXTURE_2D, 0, type, _width, _height, 0, type, GL_UNSIGNED_BYTE, la_data);
+			delete[] la_data;
 		}
 		else
-		{
-		//	while (glGetError() != GL_NO_ERROR);
-
 			glTexImage2D(GL_TEXTURE_2D, 0, type, _width, _height, 0, type, GL_UNSIGNED_BYTE, _data);
-			if (glGetError() != GL_NO_ERROR)
-			{
-				LOG(LogError) << "CreateTexture error: glTexImage2D failed";
-				destroyTexture(texture);
-				return 0;
-			}
+
+		if (glGetError() != GL_NO_ERROR)
+		{
+			LOG(LogError) << "CreateTexture error: glTexImage2D failed";
+			destroyTexture(texture);
+			return 0;
 		}
 
 		if (texture != 0)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4c8a9e5c-fc5b-4c37-a6a2-8cbd80ea33f4)
When the game is launched and then exited back to ES, the font of the popupkeyboard becomes distorted.
Vertical lines appear on the letters Q, A, and S.

This issue occurs when built with GLES20.

Original issue from: https://github.com/EmuELEC/EmuELEC/issues/878
Original PR: https://github.com/EmuELEC/emuelec-emulationstation/pull/100

from https://github.com/batocera-linux/batocera-emulationstation/pull/1869
