### PR TITLE
Hide manual controller-to-player assignment from controller settings

### DIFF
--- a/es-app/src/guis/GuiControllersSettings.cpp
+++ b/es-app/src/guis/GuiControllersSettings.cpp
@@ -184,6 +184,7 @@ GuiControllersSettings::GuiControllersSettings(Window* wnd, int autoSel) : GuiSe
 	if (Settings::getInstance()->getBool("ShowControllerActivity"))
 		addSwitch(_("SHOW CONTROLLER BATTERY LEVEL"), "ShowControllerBattery", true);
 
+#ifndef KNULLI
 	addGroup(controllers_group_label);
 
 	// Here we go; for each player
@@ -323,7 +324,7 @@ GuiControllersSettings::GuiControllersSettings(Window* wnd, int autoSel) : GuiSe
 		// Populate controllers list
 		addWithLabel(label, inputOptionList);
 	}
-#endif
+#endif // WIN32
 
 	addSaveFunc([this, options, window]
 	{
@@ -360,6 +361,9 @@ GuiControllersSettings::GuiControllersSettings(Window* wnd, int autoSel) : GuiSe
 		// this is dependant of this configuration, thus update it
 		InputManager::getInstance()->computeLastKnownPlayersDeviceIndexes();
 	});
+
+#endif // KNULLI
+
 }
 
 void GuiControllersSettings::openControllersSpecificSettings_sindengun()


### PR DESCRIPTION
**WARNING: Only use with the auto-assignment by @Mikhailzrick**

The auto-assignment of controllers to players will not go together with the manual assignment from Batocera. Hence, I disabled the entire section for manual assignments via `ifndef KNULLI`.

Tested on the RGCubeXX.