### PR TITLE
[Netplay] Fix client getting stuck during hotspot scanning

### DIFF
--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -1555,6 +1555,11 @@ std::vector<std::string> ApiSystem::getWifiNetworks(bool scan)
 	return executeEnumerationScript(scan ? "batocera-wifi scanlist" : "batocera-wifi list");
 }
 
+void ApiSystem::scanWifiNetworks()
+{
+	executeScript("batocera-wifi scanlist &");
+}
+
 std::string ApiSystem::getWifiRoute()
 {
 	std::vector<std::string> result = executeEnumerationScript("batocera-wifi getroute");

--- a/es-app/src/ApiSystem.h
+++ b/es-app/src/ApiSystem.h
@@ -258,6 +258,7 @@ public:
 	void setLEDBrightness(int value);
 
 	std::vector<std::string> getWifiNetworks(bool scan = false);
+	void scanWifiNetworks();
 	std::string getWifiRoute();
 
 	bool downloadFile(const std::string url, const std::string fileName, const std::string label = "", const std::function<void(const std::string)>& func = nullptr);

--- a/es-app/src/guis/GuiNetPlay.h
+++ b/es-app/src/guis/GuiNetPlay.h
@@ -81,6 +81,7 @@ public:
 
 private:
 	void startRequest();
+	void findHotspot();
 
 	bool populateFromJson(const std::string json);
 	bool populateFromLan();
@@ -95,6 +96,8 @@ private:
 
 	int								mLanLobbySocket;
 	int								mLanLobbySocketTimeout;
+
+	bool							mFindingHotspot;
 
 	NinePatchComponent				mBackground;
 	ComponentGrid					mGrid;


### PR DESCRIPTION
https://github.com/user-attachments/assets/744ad442-7300-49fa-94b3-f770a53b4830

Here's a video showing the updated behavior.

Netplay client no longer freezes or becomes unresponsive while searching for nearby hotspots.
Instead, it performs retries in the background without blocking the UI.