### PR TITLE
Introduced limited recursion depth (can be disabled optionally)

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -66,7 +66,6 @@ bool SystemData::IsManufacturerSupported = false;
 SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envData, std::vector<EmulatorData>* pEmulators, bool CollectionSystem, bool groupedSystem, bool withTheme, bool loadThemeOnlyIfElements) :
 	mMetadata(meta), mEnvData(envData), mIsCollectionSystem(CollectionSystem), mIsGameSystem(true)
 {
-
 	mBindableRandom = nullptr;
 	mSaveRepository = nullptr;
 	mIsCheevosSupported = -1;

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -66,6 +66,8 @@ bool SystemData::IsManufacturerSupported = false;
 SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envData, std::vector<EmulatorData>* pEmulators, bool CollectionSystem, bool groupedSystem, bool withTheme, bool loadThemeOnlyIfElements) :
 	mMetadata(meta), mEnvData(envData), mIsCollectionSystem(CollectionSystem), mIsGameSystem(true)
 {
+	std::string systemName = getName();
+
 	mBindableRandom = nullptr;
 	mSaveRepository = nullptr;
 	mIsCheevosSupported = -1;
@@ -73,6 +75,14 @@ SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envDat
 	mGameListHash = 0;
 	mGameCountInfo = nullptr;
 	mSortId = Settings::getInstance()->getInt(getName() + ".sort");
+	mUnlimitedRecursiveDepth = Settings::getInstance()->getBool(getName() + ".unlimited_recursive_depth");
+	int depth;
+	if (mUnlimitedRecursiveDepth) {
+		depth = -1;
+	} else {
+		depth = 1;
+	}
+
 	mGridSizeOverride = Vector2f(0, 0);
 
 	mFilterIndex = nullptr;
@@ -96,7 +106,7 @@ SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envDat
 
 		if (!Settings::ParseGamelistOnly())
 		{
-			populateFolder(mRootFolder, fileMap);
+			populateFolder(mRootFolder, fileMap, depth);
 
 			if (!UIModeController::LoadEmptySystems())
 			{
@@ -226,7 +236,7 @@ void SystemData::setIsGameSystemStatus()
 	mIsGameSystem = (mMetadata.name != "retropie" && mMetadata.name != "retrobat");
 }
 
-void SystemData::populateFolder(FolderData* folder, std::unordered_map<std::string, FileData*>& fileMap)
+void SystemData::populateFolder(FolderData* folder, std::unordered_map<std::string, FileData*>& fileMap, int depth)
 {
 	const std::string& folderPath = folder->getPath();
 
@@ -290,6 +300,11 @@ void SystemData::populateFolder(FolderData* folder, std::unordered_map<std::stri
 		{
 			std::string fn = Utils::String::toLower(Utils::FileSystem::getFileName(filePath));
 
+			// Do not recurse into folders if remaining depth is 0
+			if (depth == 0) {
+				continue;
+			}
+
 			// Never look in "artwork", reserved for mame roms artwork
 			if (fn == "artwork")
 				continue;
@@ -324,7 +339,7 @@ void SystemData::populateFolder(FolderData* folder, std::unordered_map<std::stri
 				continue;			
 
 			FolderData* newFolder = new FolderData(filePath, this);
-			populateFolder(newFolder, fileMap);
+			populateFolder(newFolder, fileMap, depth - 1);
 
 			//ignore folders that do not contain games
 			if(newFolder->getChildren().size() == 0)
@@ -1568,6 +1583,12 @@ void SystemData::setSortId(const unsigned int sortId)
 {
 	mSortId = sortId;
 	Settings::getInstance()->setInt(getName() + ".sort", mSortId);
+}
+
+void SystemData::setUnlimitedRecursiveDepth(const bool unlimitedRecursiveDepth)
+{
+	mUnlimitedRecursiveDepth = unlimitedRecursiveDepth;
+	Settings::getInstance()->setBool(getName() + ".unlimited_recursive_depth", mUnlimitedRecursiveDepth);
 }
 
 bool SystemData::setSystemViewMode(std::string newViewMode, Vector2f gridSizeOverride, bool setChanged)

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -66,7 +66,6 @@ bool SystemData::IsManufacturerSupported = false;
 SystemData::SystemData(const SystemMetadata& meta, SystemEnvironmentData* envData, std::vector<EmulatorData>* pEmulators, bool CollectionSystem, bool groupedSystem, bool withTheme, bool loadThemeOnlyIfElements) :
 	mMetadata(meta), mEnvData(envData), mIsCollectionSystem(CollectionSystem), mIsGameSystem(true)
 {
-	std::string systemName = getName();
 
 	mBindableRandom = nullptr;
 	mSaveRepository = nullptr;

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -113,7 +113,7 @@ public:
 	static bool IsManufacturerSupported;
 	static bool hasDirtySystems();
 	static void deleteSystems();
-	static bool loadConfig(Window* window = nullptr); //Load the system config file at getConfigPath(). Returns true if no errors were encountered. An example will be written if the file doesn't exist.	
+	static bool loadConfig(Window* window = nullptr); //Load the system config file at getConfigPath(). Returns true if no errors were encountered. An example will be written if the file doesn't exist.
 	static std::string getConfigPath();
 	
 	bool loadFeatures();
@@ -125,7 +125,7 @@ public:
 	inline bool isCollection() { return mIsCollectionSystem; };
 	inline bool isGameSystem() { return mIsGameSystem; };
 
-	inline bool isGroupSystem() { return mIsGroupSystem; };	
+	inline bool isGroupSystem() { return mIsGroupSystem; };
 	bool isGroupChildSystem();
 
 	bool isVisible();
@@ -168,6 +168,9 @@ public:
 
 	unsigned int getSortId() const { return mSortId; };
 	void setSortId(const unsigned int sortId = 0);
+
+	bool isUnlimitedRecursiveDepth() const { return mUnlimitedRecursiveDepth; };
+	void setUnlimitedRecursiveDepth(const bool unlimitedRecursiveDepth = false);
 
 	std::string getSystemViewMode() const { if (mViewMode == "automatic") return ""; else return mViewMode; };
 	bool setSystemViewMode(std::string newViewMode, Vector2f gridSizeOverride = Vector2f(0, 0), bool setChanged = true);
@@ -248,7 +251,7 @@ private:
 	SystemEnvironmentData* mEnvData;
 	std::shared_ptr<ThemeData> mTheme;
 
-	void populateFolder(FolderData* folder, std::unordered_map<std::string, FileData*>& fileMap);
+	void populateFolder(FolderData* folder, std::unordered_map<std::string, FileData*>& fileMap, int depth);
 	void indexAllGameFilters(const FolderData* folder);
 	void setIsGameSystemStatus();
 	void removeMultiDiskContent(std::unordered_map<std::string, FileData*>& fileMap);
@@ -264,8 +267,9 @@ private:
 	std::vector<EmulatorData> mEmulators;
 	
 	unsigned int mSortId;
+	bool mUnlimitedRecursiveDepth;
 	std::string mViewMode;
-	Vector2f    mGridSizeOverride;	
+	Vector2f    mGridSizeOverride;
 	
 	std::shared_ptr<bool> mShowFilenames;
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -156,10 +156,12 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, IGameListView* gamelist, 
 		}
 		mMenu.addWithLabel(_("SORT GAMES BY"), mListSort);
 
-		mMenu.addGroup(_("GAME DETECTION OPTIONS"));
-	    mSwitchUnlimitedRecursiveDepth = std::make_shared<SwitchComponent>(mWindow);
-	    mSwitchUnlimitedRecursiveDepth->setState(mSystem->isUnlimitedRecursiveDepth());
-	    mMenu.addWithDescription("UNLIMITED RECURSION DEPTH", "Might slow down gamelist updates significantly!", mSwitchUnlimitedRecursiveDepth);
+		if (!system->isCollection()) {
+			mMenu.addGroup(_("GAME DETECTION OPTIONS"));
+			mSwitchUnlimitedRecursiveDepth = std::make_shared<SwitchComponent>(mWindow);
+			mSwitchUnlimitedRecursiveDepth->setState(mSystem->isUnlimitedRecursiveDepth());
+			mMenu.addWithDescription("UNLIMITED RECURSION DEPTH", "Might slow down gamelist updates significantly!", mSwitchUnlimitedRecursiveDepth);
+		}
 
 	}
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -154,8 +154,13 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, IGameListView* gamelist, 
 			const FileSorts::SortType& sort = FileSorts::getSortTypes().at(i);
 			mListSort->add(sort.icon + sort.description, sort.id, sort.id == currentSortId); // TODO - actually make the sort type persistent
 		}
+		mMenu.addWithLabel(_("SORT GAMES BY"), mListSort);
 
-		mMenu.addWithLabel(_("SORT GAMES BY"), mListSort);	
+		mMenu.addGroup(_("GAME DETECTION OPTIONS"));
+	    mSwitchUnlimitedRecursiveDepth = std::make_shared<SwitchComponent>(mWindow);
+	    mSwitchUnlimitedRecursiveDepth->setState(mSystem->isUnlimitedRecursiveDepth());
+	    mMenu.addWithDescription("UNLIMITED RECURSION DEPTH", "Might slow down gamelist updates significantly!", mSwitchUnlimitedRecursiveDepth);
+
 	}
 
 	if (!isInRelevancyMode)
@@ -359,6 +364,11 @@ GuiGamelistOptions::~GuiGamelistOptions()
 		(*it)();
 
 	bool saveSort = !fromPlaceholder || mSystem == CollectionSystemManager::get()->getCustomCollectionsBundle();
+
+	// Set
+	if (mSwitchUnlimitedRecursiveDepth->getState() != mSystem->isUnlimitedRecursiveDepth()) {
+		mSystem->setUnlimitedRecursiveDepth(mSwitchUnlimitedRecursiveDepth->getState());
+	}
 
 	// apply sort
 	if (mListSort && saveSort && mListSort->getSelected() != mSystem->getSortId())

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -4,6 +4,7 @@
 
 #include "components/MenuComponent.h"
 #include "components/OptionListComponent.h"
+#include "components/SwitchComponent.h"
 #include "FileData.h"
 #include "GuiComponent.h"
 
@@ -46,6 +47,7 @@ private:
 
 	typedef OptionListComponent<unsigned int> SortList;
 	std::shared_ptr<SortList> mListSort;
+	std::shared_ptr<SwitchComponent> mSwitchUnlimitedRecursiveDepth;
 
 	std::shared_ptr<GuiComponent> mTextFilter;
 


### PR DESCRIPTION
To speed up the ES launch process, I limited the recursion depth for the file scan (per system) to 1. This means that

* `/userdata/roms/snes/foo.sfc` will be detected
* `/userdata/roms/snes/level1/bar.sfc` will be detected
* `/userdata/roms/snes/level1/level2/foobar.sfc` will **NOT** be detected

I believe most users are (hopefully) sane enough not tave any annoyingly deep folder structure.

However, if they do, they can go to the respective system's settings and turn on *Unlimited Recursion Depth*. This will bring back the original unlimited depth scan which causes the annoying slowdowns when loading ES because scanning ScummVM, ports, etc. with all the asset subfolders can take quite some time.