### PR TITLE
Renamed "Overclock" menu to "CPU Clock Rate"

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1831,7 +1831,7 @@ void GuiMenu::openSystemSettings()
 		}
 
 		// overclocking
-		s->addWithLabel(_("OVERCLOCK"), overclock_choice);
+		s->addWithLabel(_("CPU CLOCK SPEED"), overclock_choice);
 
 		s->addSaveFunc([overclock_choice, window, s]
 		{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1789,7 +1789,7 @@ void GuiMenu::openSystemSettings()
 	// Overclock choice
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::OVERCLOCK))
 	{
-		auto overclock_choice = std::make_shared<OptionListComponent<std::string>>(window, _("OVERCLOCK"), false);
+		auto overclock_choice = std::make_shared<OptionListComponent<std::string>>(window, _("CPU CLOCK RATE"), false);
 
 		std::string currentOverclock = Settings::getInstance()->getString("Overclock");
 		if (currentOverclock == "")

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1831,7 +1831,7 @@ void GuiMenu::openSystemSettings()
 		}
 
 		// overclocking
-		s->addWithLabel(_("CPU CLOCK SPEED"), overclock_choice);
+		s->addWithLabel(_("CPU CLOCK RATE"), overclock_choice);
 
 		s->addSaveFunc([overclock_choice, window, s]
 		{


### PR DESCRIPTION
Because the name is confusing, on the H700s it is more like underclocking.