### PR TITLE
Fix segfault on exiting VIEW OPTIONS

### DIFF
--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -368,7 +368,7 @@ GuiGamelistOptions::~GuiGamelistOptions()
 	bool saveSort = !fromPlaceholder || mSystem == CollectionSystemManager::get()->getCustomCollectionsBundle();
 
 	// Set
-	if (mSwitchUnlimitedRecursiveDepth->getState() != mSystem->isUnlimitedRecursiveDepth()) {
+	if (mSwitchUnlimitedRecursiveDepth != nullptr && mSwitchUnlimitedRecursiveDepth->getState() != mSystem->isUnlimitedRecursiveDepth()) {
 		mSystem->setUnlimitedRecursiveDepth(mSwitchUnlimitedRecursiveDepth->getState());
 	}
 


### PR DESCRIPTION
Doing this results in a segfault.

1. Go to the LAST PLAYED list in ES.
2. Press the SELECT button to open the OPTIONS menu.
3. Press BACK.
4. ES exits.

Added a nullptr check to resolve the issue.