### PR TITLE
Add user community relay server feature with SEOUL as the first preset

### DIFF
--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -1,10 +1,17 @@
 #include "GuiNetPlaySettings.h"
 #include "SystemConf.h"
 #include "ThreadedHasher.h"
+#include "components/OptionListComponent.h"
 #include "components/SwitchComponent.h"
 #include "GuiHashStart.h"
+#include <unordered_map>
 
-GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("NETPLAY SETTINGS").c_str())
+static std::unordered_map<std::string, std::string> communityRelayServers =
+{
+	{"seoul",		"138.2.119.137"},
+};
+
+GuiNetPlaySettings::GuiNetPlaySettings(Window* window, int selectItem) : GuiSettings(window, _("NETPLAY SETTINGS").c_str())
 {
 	std::string port = SystemConf::getInstance()->get("global.netplay.port");
 	if (port.empty())
@@ -20,8 +27,8 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 	addGroup(_("OPTIONS"));
 
 	addInputTextRow(_("PORT"), "global.netplay.port", false);
-	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" },{ _("CUSTOM") , "custom" } }, "global.netplay.relay", false);
-	addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
+
+	addRelayServerOptions(selectItem);
 
 #ifndef WIN32
 	auto enableHotspot = std::make_shared<SwitchComponent>(mWindow);
@@ -57,4 +64,76 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 			}
 		}
 	});
+}
+
+void GuiNetPlaySettings::addRelayServerOptions(int selectItem)
+{
+	const std::string customRelayServerAddress = SystemConf::getInstance()->get("global.netplay.customserver");
+	std::string selectedRelayServer = SystemConf::getInstance()->get("global.netplay.relay");
+	if (selectedRelayServer == "custom")
+	{
+		for (const auto& kv : communityRelayServers)
+		{
+			if (kv.second != customRelayServerAddress)
+				continue;
+
+			selectedRelayServer = kv.first;
+			break;
+		}
+	}
+
+	auto relayServer = std::make_shared<OptionListComponent<std::string>>(mWindow, _("USE RELAY SERVER"), false);
+	relayServer->add(_("NONE"), "", selectedRelayServer.empty());
+
+	// Official RetroArch relay servers
+	relayServer->add(_("NEW YORK"), "nyc", selectedRelayServer == "nyc");
+	relayServer->add(_("MADRID"), "madrid", selectedRelayServer == "madrid");
+	relayServer->add(_("MONTREAL"), "montreal", selectedRelayServer == "montreal");
+	relayServer->add(_("SAO PAULO"), "saopaulo", selectedRelayServer == "saopaulo");
+
+	// User Community relay servers
+	relayServer->add(_("SEOUL"), "seoul", selectedRelayServer == "seoul");
+
+	// Custom relay server
+	relayServer->add(_("CUSTOM"), "custom", selectedRelayServer == "custom");
+
+	if (!relayServer->hasSelection())
+		relayServer->selectFirstItem();
+
+	addWithLabel(_("USE RELAY SERVER"), relayServer, selectItem == 1);
+
+	relayServer->setSelectedChangedCallback([this](const std::string& newRelayServer)
+	{
+		std::string originalCustomServerAddress = SystemConf::getInstance()->get("global.netplay.customserver");
+		std::string backupCustomServerAddress = SystemConf::getInstance()->get("global.netplay.customserver.backup");
+
+		if (communityRelayServers.find(newRelayServer) != communityRelayServers.end())
+		{
+			SystemConf::getInstance()->set("global.netplay.relay", "custom");
+			SystemConf::getInstance()->set("global.netplay.customserver", communityRelayServers[newRelayServer]);
+
+			if (!std::any_of(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.second == originalCustomServerAddress; }))
+				SystemConf::getInstance()->set("global.netplay.customserver.backup", originalCustomServerAddress);
+		}
+		else if (newRelayServer == "custom")
+		{
+			SystemConf::getInstance()->set("global.netplay.relay", newRelayServer);
+
+			if (!backupCustomServerAddress.empty())
+				SystemConf::getInstance()->set("global.netplay.customserver", backupCustomServerAddress);
+			else if (std::any_of(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.second == originalCustomServerAddress; }))
+				SystemConf::getInstance()->set("global.netplay.customserver", "");
+		}
+		else
+		{
+			SystemConf::getInstance()->set("global.netplay.relay", newRelayServer);
+		}
+
+		Window* pw = mWindow;
+		delete this;
+		pw->pushGui(new GuiNetPlaySettings(pw, 1));
+	});
+
+	if (selectedRelayServer == "custom" && std::find_if(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.second == customRelayServerAddress; }) == communityRelayServers.end())
+		addInputTextRow(_("CUSTOM RELAY SERVER"), "global.netplay.customserver", false);
 }

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -6,10 +6,9 @@
 #include "GuiHashStart.h"
 #include <unordered_map>
 
-static std::unordered_map<std::string, std::string> communityRelayServers =
-{
-	{"seoul",		"138.2.119.137"},
-};
+#define fake_gettext_seoul _("SEOUL")
+
+static std::vector<std::pair<std::string, std::string>> communityRelayServers;
 
 GuiNetPlaySettings::GuiNetPlaySettings(Window* window, int selectItem) : GuiSettings(window, _("NETPLAY SETTINGS").c_str())
 {
@@ -66,8 +65,58 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window, int selectItem) : GuiSett
 	});
 }
 
+void GuiNetPlaySettings::loadCommunityRelayServers()
+{
+	communityRelayServers.clear();
+
+	std::string xmlpath = ResourceManager::getInstance()->getResourcePath(":/community_relay_servers.xml");
+	if (!Utils::FileSystem::exists(xmlpath))
+		return;
+
+	LOG(LogInfo) << "Parsing XML file \"" << xmlpath << "\"...";
+
+	pugi::xml_document doc;
+	pugi::xml_parse_result result = doc.load_file(WINSTRINGW(xmlpath).c_str());
+
+	if (!result)
+	{
+		LOG(LogError) << "Error parsing XML file \"" << xmlpath << "\"!\n	" << result.description();
+		return;
+	}
+
+	pugi::xml_node root = doc.child("community_relay_servers");
+	if (!root)
+	{
+		LOG(LogError) << "Could not find <community_relay_servers> node in \"" << xmlpath << "\"!";
+		return;
+	}
+
+	for (pugi::xml_node server = root.child("server"); server; server = server.next_sibling("server"))
+	{
+		if (!server.attribute("id"))
+			continue;
+
+		std::string id = server.attribute("id").as_string();
+		if (id.empty())
+			continue;
+
+		if (!server.attribute("address"))
+			continue;
+
+		std::string address = server.attribute("address").as_string();
+		if (address.empty())
+			continue;
+
+		communityRelayServers.emplace_back(id, address);
+		LOG(LogInfo) << "Loaded community relay server: id=\"" << id << "\", address=\"" << address << "\"";
+	}
+}
+
 void GuiNetPlaySettings::addRelayServerOptions(int selectItem)
 {
+	if (communityRelayServers.empty())
+		loadCommunityRelayServers();
+
 	const std::string customRelayServerAddress = SystemConf::getInstance()->get("global.netplay.customserver");
 	std::string selectedRelayServer = SystemConf::getInstance()->get("global.netplay.relay");
 	if (selectedRelayServer == "custom")
@@ -92,7 +141,11 @@ void GuiNetPlaySettings::addRelayServerOptions(int selectItem)
 	relayServer->add(_("SAO PAULO"), "saopaulo", selectedRelayServer == "saopaulo");
 
 	// User Community relay servers
-	relayServer->add(_("SEOUL"), "seoul", selectedRelayServer == "seoul");
+	for (auto& kv : communityRelayServers)
+	{
+		std::string serverName = kv.first;
+		relayServer->add(Utils::String::toUpper(serverName.c_str()), serverName, selectedRelayServer == serverName);
+	}
 
 	// Custom relay server
 	relayServer->add(_("CUSTOM"), "custom", selectedRelayServer == "custom");
@@ -107,12 +160,14 @@ void GuiNetPlaySettings::addRelayServerOptions(int selectItem)
 		std::string originalCustomServerAddress = SystemConf::getInstance()->get("global.netplay.customserver");
 		std::string backupCustomServerAddress = SystemConf::getInstance()->get("global.netplay.customserver.backup");
 
-		if (communityRelayServers.find(newRelayServer) != communityRelayServers.end())
+		auto it = std::find_if(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.first == newRelayServer; });
+		if (it != communityRelayServers.end())
 		{
 			SystemConf::getInstance()->set("global.netplay.relay", "custom");
-			SystemConf::getInstance()->set("global.netplay.customserver", communityRelayServers[newRelayServer]);
+			SystemConf::getInstance()->set("global.netplay.customserver", it->second);
 
-			if (!std::any_of(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.second == originalCustomServerAddress; }))
+			bool foundOriginal = std::any_of(communityRelayServers.begin(), communityRelayServers.end(), [&](const auto& kv) { return kv.second == originalCustomServerAddress; });
+			if (!foundOriginal)
 				SystemConf::getInstance()->set("global.netplay.customserver.backup", originalCustomServerAddress);
 		}
 		else if (newRelayServer == "custom")
@@ -128,7 +183,7 @@ void GuiNetPlaySettings::addRelayServerOptions(int selectItem)
 		{
 			SystemConf::getInstance()->set("global.netplay.relay", newRelayServer);
 		}
-
+		
 		Window* pw = mWindow;
 		delete this;
 		pw->pushGui(new GuiNetPlaySettings(pw, 1));

--- a/es-app/src/guis/GuiNetPlaySettings.h
+++ b/es-app/src/guis/GuiNetPlaySettings.h
@@ -7,5 +7,8 @@ class Window;
 class GuiNetPlaySettings : public GuiSettings
 {
 public:
-	GuiNetPlaySettings(Window* window);
+	GuiNetPlaySettings(Window* window, int selectItem = -1);
+
+private:
+	void addRelayServerOptions(int selectItem);
 };

--- a/es-app/src/guis/GuiNetPlaySettings.h
+++ b/es-app/src/guis/GuiNetPlaySettings.h
@@ -10,5 +10,6 @@ public:
 	GuiNetPlaySettings(Window* window, int selectItem = -1);
 
 private:
+	void loadCommunityRelayServers();
 	void addRelayServerOptions(int selectItem);
 };

--- a/locale/emulationstation2.pot
+++ b/locale/emulationstation2.pot
@@ -2747,27 +2747,6 @@ msgstr ""
 msgid "PORT"
 msgstr ""
 
-msgid "USE RELAY SERVER"
-msgstr ""
-
-msgid "NEW YORK"
-msgstr ""
-
-msgid "MADRID"
-msgstr ""
-
-msgid "MONTREAL"
-msgstr ""
-
-msgid "SAO PAULO"
-msgstr ""
-
-msgid "CUSTOM"
-msgstr ""
-
-msgid "CUSTOM RELAY SERVER"
-msgstr ""
-
 msgid "AUTOMATICALLY USE HOTSPOT FOR LOCAL NETPLAY"
 msgstr ""
 
@@ -2799,6 +2778,30 @@ msgid "GAME INDEXES"
 msgstr ""
 
 msgid "INDEX NEW GAMES AT STARTUP"
+msgstr ""
+
+msgid "USE RELAY SERVER"
+msgstr ""
+
+msgid "NEW YORK"
+msgstr ""
+
+msgid "MADRID"
+msgstr ""
+
+msgid "MONTREAL"
+msgstr ""
+
+msgid "SAO PAULO"
+msgstr ""
+
+msgid "SEOUL"
+msgstr ""
+
+msgid "CUSTOM"
+msgstr ""
+
+msgid "CUSTOM RELAY SERVER"
 msgstr ""
 
 #, c-format

--- a/locale/lang/ko/LC_MESSAGES/emulationstation2.po
+++ b/locale/lang/ko/LC_MESSAGES/emulationstation2.po
@@ -1655,7 +1655,7 @@ msgid "UPDATES & DOWNLOADS"
 msgstr "업데이트 & 다운로드"
 
 msgid "DEVICE SETTINGS"
-msgstr ""
+msgstr "장치 설정"
 
 msgid "SYSTEM SETTINGS"
 msgstr "시스템 설정"
@@ -2782,6 +2782,9 @@ msgstr "몬트리올"
 msgid "SAO PAULO"
 msgstr "상파울루"
 
+msgid "SEOUL"
+msgstr "서울"
+
 msgid "CUSTOM"
 msgstr "커스텀"
 
@@ -3141,7 +3144,7 @@ msgid "POWER SAVING AND BATTERY LIFE"
 msgstr ""
 
 msgid "POWER MANAGEMENT"
-msgstr ""
+msgstr "전력 관리"
 
 msgid "DEVICE CUSTOMIZATION"
 msgstr ""
@@ -3156,7 +3159,7 @@ msgid "INSTALL PICO-8"
 msgstr ""
 
 msgid "USB MODE"
-msgstr ""
+msgstr "USB 모드"
 
 msgid "Native Pico-8 was successfully installed."
 msgstr ""
@@ -3168,7 +3171,7 @@ msgid "MTP"
 msgstr ""
 
 msgid "Set the USB mode to access your device."
-msgstr ""
+msgstr "USB 연결 방식을 선택합니다."
 
 msgid "TOGGLE SWITCH MODE"
 msgstr ""
@@ -3189,44 +3192,44 @@ msgid "BATTERY SAVING"
 msgstr ""
 
 msgid "DIM"
-msgstr ""
+msgstr "어둡게"
 
 msgid "DISPLAY OFF"
-msgstr ""
+msgstr "화면 끄기"
 
 msgid "SUSPEND"
-msgstr ""
+msgstr "절전 모드"
 
 msgid "SHUTDOWN"
-msgstr ""
+msgstr "전원 끄기"
 
 msgid "IDLE TIME"
-msgstr ""
+msgstr "유휴 시간"
 
 msgid ""
 "Battery save mode is activated after idle time has passed without any input."
-msgstr ""
+msgstr "입력 없이 유휴 시간이 경과하면 설정한 전력 관리 모드가 활성화됩니다."
 
 msgid "EXTENDED MODE"
-msgstr ""
+msgstr "확장 모드"
 
 msgid "EXTENDED IDLE TIME"
-msgstr ""
+msgstr "확장 유휴 시간"
 
 msgid ""
 "Secondary timer which starts after initial idle time has passed without any "
 "input."
-msgstr ""
+msgstr "입력 없이 유휴 시간이 경과하면 설정된 전력 관리의 확장 모드가 활성화됩니다."
 
 msgid "AGGRESSIVE BATTERY SAVER"
-msgstr ""
+msgstr "에너지 절약 모드"
 
 msgid ""
 "Optimizes battery life with extra power-saving measures during system idle."
-msgstr ""
+msgstr "유휴 상태일 때도 배터리 사용을 최적화합니다."
 
 msgid "LID CLOSE MODE"
-msgstr ""
+msgstr "화면을 닫을 때의 동작"
 
 msgid "REGULAR LED MODE AND COLOR"
 msgstr ""

--- a/resources/community_relay_servers.xml
+++ b/resources/community_relay_servers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<community_relay_servers>
+  <server id="seoul" address="138.2.119.137" author_email="bulzipke@naver.com" />
+</community_relay_servers>


### PR DESCRIPTION
Knulli currently provides RetroArch’s official relay servers as options for netplay.
This update adds support for user community relay servers, allowing additional community-hosted relays to be included.
I have added a relay server for Korean players (SEOUL) as the first community option, and I hope this opens the door for more countries to add their own in the future.