### PR TITLE
Re-enabled OTA menu and added factory reset to device settings

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -80,6 +80,7 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/BoardCheck.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/CapabilityCheck.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/ExtendedGuiSettings.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/FactorySettings.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/GuiDeviceSettings.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/GuiPowerManagementSettings.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/GuiRgbSettings.h
@@ -195,6 +196,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/BoardCheck.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/CapabilityCheck.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/ExtendedGuiSettings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/FactorySettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/GuiDeviceSettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/GuiPowerManagementSettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/knulli/GuiRgbSettings.cpp

--- a/es-app/src/ApiSystem.cpp
+++ b/es-app/src/ApiSystem.cpp
@@ -234,7 +234,7 @@ std::pair<std::string, int> ApiSystem::updateSystem(const std::function<void(con
 {
 	LOG(LogDebug) << "ApiSystem::updateSystem";
 
-	std::string updatecommand = "batocera-upgrade";
+	std::string updatecommand = "knulli-upgrade";
 
 	FILE *pipe = popen(updatecommand.c_str(), "r");
 	if (pipe == nullptr)
@@ -371,7 +371,7 @@ bool ApiSystem::canUpdate(std::vector<std::string>& output)
 {
 	LOG(LogDebug) << "ApiSystem::canUpdate";
 
-	FILE *pipe = popen("batocera-config canupdate", "r");
+	FILE *pipe = popen("knulli-update-check", "r");
 	if (pipe == NULL)
 		return false;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1257,7 +1257,6 @@ void GuiMenu::openUpdatesSettings()
 		});
 	}
 
-#ifndef KNULLI
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::UPGRADE))
 	{
 		updateGui->addGroup(_("SOFTWARE UPDATES"));
@@ -1280,12 +1279,20 @@ void GuiMenu::openUpdatesSettings()
 			updatesTypeList->add("unstable", "unstable", updatesType == "unstable");
 		else
 #endif
+#if KNULLI
+			if (updatesType.empty() || updatesType != "alpha" || updatesType != "development")
+				updatesType = "stable";
+#else
 			if (updatesType.empty() || updatesType != BETA_NAME)
 				updatesType = "stable";
-
+#endif			
 		updatesTypeList->add("stable", "stable", updatesType == "stable");
+#if KNULLI
+		updatesTypeList->add("alpha", "alpha", updatesType == "alpha");
+		updatesTypeList->add("development", "development", updatesType == "development");
+#else
 		updatesTypeList->add(BETA_NAME, BETA_NAME, updatesType == BETA_NAME);
-
+#endif
 		updateGui->addWithLabel(_("UPDATE TYPE"), updatesTypeList);
 		updatesTypeList->setSelectedChangedCallback([](std::string name)
 		{
@@ -1309,7 +1316,7 @@ void GuiMenu::openUpdatesSettings()
 			}
 		});
 	}
-#endif
+
 	mWindow->pushGui(updateGui);
 }
 

--- a/es-app/src/guis/GuiUpdate.cpp
+++ b/es-app/src/guis/GuiUpdate.cpp
@@ -169,7 +169,7 @@ void GuiUpdate::update(int deltaTime)
 				if (versionExtra == "none")
 					message = Utils::String::format(_("YOU ARE CURRENTLY USING VERSION %s\nDO YOU WANT TO UPDATE TO VERSION %s?").c_str(), ApiSystem::getInstance()->getVersion().c_str(), mUpdateVersion.c_str());
 				else
-					message = Utils::String::format(_("UNOFFICIAL SYSTEM MODIFICATIONS DETECTED.\nUPGRADING COULD BREAK YOUR SYSTEM.\nDO YOU WANT TO UPDATE TO VERSION %s?").c_str(), mUpdateVersion.c_str());
+					message = Utils::String::format(_("YOUR SYSTEM HAS BEEN PATCHED OR MODIFIED.\nUPGRADING WILL REMOVE ANY PATCHES AND MODIFICATIONS.\nDO YOU WANT TO UPDATE TO VERSION %s?").c_str(), mUpdateVersion.c_str());
 
 				window->pushGui(new GuiMsgBox(window, message, _("YES"), [this]
 				{

--- a/es-app/src/guis/knulli/FactorySettings.cpp
+++ b/es-app/src/guis/knulli/FactorySettings.cpp
@@ -1,0 +1,27 @@
+#include "guis/knulli/FactorySettings.h"
+#include "utils/Platform.h"
+#include "Paths.h"
+#include "utils/FileSystemUtil.h"
+#include "utils/StringUtil.h"
+#include <stdio.h>
+#include <sys/wait.h>
+#include <fstream>
+
+const std::string FACTORY_RESET_NAME = "/usr/bin/knulli-factory-reset";
+const std::string SEPARATOR = " ";
+const std::string FORCE = "-f";
+
+int FactorySettings::applyFactoryReset()
+{
+	if (hasFactoryReset()) {
+		int result = system((FACTORY_RESET_NAME + SEPARATOR + FORCE).c_str());
+		return WEXITSTATUS(result);
+	}
+	// Installer is missing
+	return 2;
+}
+
+
+bool FactorySettings::hasFactoryReset() {
+	return Utils::FileSystem::exists(FACTORY_RESET_NAME);
+}

--- a/es-app/src/guis/knulli/FactorySettings.h
+++ b/es-app/src/guis/knulli/FactorySettings.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class FactorySettings
+{
+public:
+        static int applyFactoryReset();
+        static bool hasFactoryReset();
+
+};

--- a/es-app/src/guis/knulli/GuiDeviceSettings.cpp
+++ b/es-app/src/guis/knulli/GuiDeviceSettings.cpp
@@ -1,5 +1,7 @@
-#include "guis/knulli/ExtendedGuiSettings.h"
 #include "guis/knulli/GuiDeviceSettings.h"
+#include "guis/knulli/ExtendedGuiSettings.h"
+
+#include "guis/knulli/FactorySettings.h"
 #include "guis/knulli/GuiPowerManagementSettings.h"
 #include "guis/knulli/GuiRgbSettings.h"
 #include "guis/knulli/Pico8Installer.h"
@@ -76,6 +78,18 @@ GuiDeviceSettings::GuiDeviceSettings(Window* window) : ExtendedGuiSettings(windo
 		SystemConf::getInstance()->set("system.telemetry", switchTelemetryStatistics->getState() ? "1" : "0");
 		SystemConf::getInstance()->saveSystemConf();
 	});
+
+	if (FactorySettings::hasFactoryReset()) {
+		addGroup(_("FACTORY SETTINGS"));
+		addWithDescription(_("FACTORY RESET"), _("Reset Knulli to factory settings. All your settings will be undone."), nullptr, [this]
+		{
+			mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO RESET TO FACTORY SETTINGS? ALL YOUR SETTINGS WILL BE UNDONE! DO NOT PANIC: THE SCREEN WILL TURN OFF AND THE DEVICE WILL REBOOT AUTOMATICALLY AFTER A COUPLE OF SECONDS."), _("YES"), [this]
+				{
+					FactorySettings::applyFactoryReset();
+				},
+				_("NO"), nullptr));
+		});
+	}	
 
 }
 

--- a/es-app/src/guis/knulli/GuiDeviceSettings.cpp
+++ b/es-app/src/guis/knulli/GuiDeviceSettings.cpp
@@ -81,15 +81,15 @@ GuiDeviceSettings::GuiDeviceSettings(Window* window) : ExtendedGuiSettings(windo
 
 	if (FactorySettings::hasFactoryReset()) {
 		addGroup(_("FACTORY SETTINGS"));
-		addWithDescription(_("FACTORY RESET"), _("Reset Knulli to factory settings. All your settings will be undone."), nullptr, [this]
+		addWithDescription(_("FACTORY RESET"), _("This will reset all your Knulli settings to factory defaults. Other user data (e.g., games, BIOS files, saves, etc.) will be left untouched."), nullptr, [this]
 		{
-			mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO RESET TO FACTORY SETTINGS? ALL YOUR SETTINGS WILL BE UNDONE! DO NOT PANIC: THE SCREEN WILL TURN OFF AND THE DEVICE WILL REBOOT AUTOMATICALLY AFTER A COUPLE OF SECONDS."), _("YES"), [this]
+			mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO RESET TO FACTORY SETTINGS? ALL YOUR SETTINGS WILL BE UNDONE!\n\nDO NOT PANIC: THE SCREEN WILL TURN OFF AND THE DEVICE WILL REBOOT AUTOMATICALLY AFTER A COUPLE OF SECONDS."), _("YES"), [this]
 				{
 					FactorySettings::applyFactoryReset();
 				},
 				_("NO"), nullptr));
-		});
-	}	
+		}, "", false, true);
+	}
 
 }
 


### PR DESCRIPTION
* Re-enabled OTA menu with channels `stable`, `alpha`, and `development` (set it `batocera.conf` as `updates.type`)
* Changed update related bash calls:
    * `batocera-config canupdate` -> `knulli-update-check`
    * `batocera-upgrade` -> `knulli-upgrade`
* Factory reset only shows if `/usr/bin/knulli-factory-reset` file is present, see here: https://github.com/knulli-cfw/distribution/pull/377