### PR TITLE
Add missing localization macro to the community relay server names

### DIFF
--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -148,7 +148,8 @@ void GuiNetPlaySettings::addRelayServerOptions(int selectItem)
 	for (auto& kv : communityRelayServers)
 	{
 		std::string serverName = kv.first;
-		relayServer->add(Utils::String::toUpper(serverName.c_str()), serverName, selectedRelayServer == serverName);
+		std::string upperName = Utils::String::toUpper(serverName.c_str());
+		relayServer->add(_(upperName.c_str()), serverName, selectedRelayServer == serverName);
 	}
 
 	// Custom relay server


### PR DESCRIPTION
Fixes missing localization on community relay server names.

from https://github.com/batocera-linux/batocera-emulationstation/pull/1957