### PR TITLE
disable-oc-reboot-prompt

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -857,7 +857,7 @@ void GuiMenu::openDeveloperSettings()
 
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::DISKFORMAT))
 	s->addEntry(_("FORMAT A DISK"), true, [this] { openFormatDriveSettings(); });
-	
+
 	#ifdef KNULLI
 	s->addWithDescription(_("DISK CHECK"), _("Verify the integrity of your SD cards."), nullptr, [this, s]
 	{
@@ -1285,7 +1285,7 @@ void GuiMenu::openUpdatesSettings()
 #else
 			if (updatesType.empty() || updatesType != BETA_NAME)
 				updatesType = "stable";
-#endif			
+#endif
 		updatesTypeList->add("stable", "stable", updatesType == "stable");
 #if KNULLI
 		updatesTypeList->add("alpha", "alpha", updatesType == "alpha");
@@ -1814,7 +1814,7 @@ void GuiMenu::openSystemSettings()
 	// Overclock choice
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::OVERCLOCK))
 	{
-		auto overclock_choice = std::make_shared<OptionListComponent<std::string>>(window, _("CPU CLOCK RATE"), false);
+		auto overclock_choice = std::make_shared<OptionListComponent<std::string>>(window, _("MAX CPU FREQUENCY"), false);
 
 		std::string currentOverclock = Settings::getInstance()->getString("Overclock");
 		if (currentOverclock == "")
@@ -1863,7 +1863,7 @@ void GuiMenu::openSystemSettings()
 			if (overclock_choice->changed() && Settings::getInstance()->setString("Overclock", overclock_choice->getSelected()))
 			{
 				ApiSystem::getInstance()->setOverclock(overclock_choice->getSelected());
-				s->setVariable("reboot", true);
+				//s->setVariable("reboot", true); disable reboot prompt
 			}
 		});
 	}


### PR DESCRIPTION
Disables the prompt to reboot when changing cpu frequency. Also change label to MAX CPU FREQUENCY to be more explicit as far as what it's for.