### PR TITLE
Added alternative names for RPGs

### DIFF
--- a/resources/genres.xml
+++ b/resources/genres.xml
@@ -506,6 +506,9 @@
     <nom_es>Juegos de rol</nom_es>
     <nom_pt>Jogos de RPG</nom_pt>
     <nom_ja>ロールプレイング</nom_ja>
+    <altname>Role playing game</altname>
+    <altname>RPG</altname>
+    <altname>Rollenspiel</altname>
   </genre>
   <genre>
     <id>20688</id>


### PR DESCRIPTION
Some scraper sources scrape RPGs as `Role playing game`, however, Knulli expects RPGs to be labeled as `Role playing games` in the genre field.

Thankfully, there's an `altname` option, so I added some alternative names for RPGs.