### PR TITLE
Added a toggle for dumping SRM into the corresponding SRM file while still in-game

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2663,19 +2663,20 @@ void GuiMenu::openGamesSettings()
 
 #ifdef KNULLI
 	// SET SRM FILE UPDATE INTERVAL
-	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SRM FILE UPDATE INTERVAL (MINUTES)"));
+	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SRM FILE UPDATE INTERVAL"));
 	autosaveInterval->addRange({
 		{ _("AUTO"), "" },
-		{ _("ONLY ON GAME EXIT (DEFAULT)"), "0" },
-		{ _("1"), "1" },
-		{ _("5"), "5" },
-		{ _("10"), "10" },
-		{ _("15"), "15" },
-		{ _("30"), "30" },
-		{ _("60"), "60" } },
+		{ _("5 Sec."), "5" },
+		{ _("10 Sec."), "10" },
+		{ _("15 Sec."), "15" },
+		{ _("30 Sec."), "30" },
+		{ _("1 Min. (DEFAULT)"), "60" },
+		{ _("5 Min."), "300" },
+		{ _("10 Min."), "600" },
+		{ _("ONLY ON GAME EXIT"), "0" } },
 		SystemConf::getInstance()->get("global.srm_update_interval"));
 
-	s->addWithDescription(_("SRM FILE UPDATE INTERVAL (MINUTES)"), _("For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes."), autosaveInterval);
+	s->addWithDescription(_("SRM FILE UPDATE INTERVAL"), _("For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X seconds/minutes."), autosaveInterval);
 	s->addSaveFunc([autosaveInterval] { SystemConf::getInstance()->set("global.srm_update_interval", autosaveInterval->getSelected()); });
 #endif
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2665,7 +2665,8 @@ void GuiMenu::openGamesSettings()
 	// SET SRM FILE UPDATE INTERVAL
 	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SRM FILE UPDATE INTERVAL (MINUTES)"));
 	autosaveInterval->addRange({
-		{ _("ONLY ON GAME EXIT (DEFAULT)"), "" },
+		{ _("AUTO"), "" },
+		{ _("ONLY ON GAME EXIT (DEFAULT)"), "0" },
 		{ _("1"), "1" },
 		{ _("5"), "5" },
 		{ _("10"), "10" },

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2662,22 +2662,11 @@ void GuiMenu::openGamesSettings()
 	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getState() ? "1" : ""); });
 
 #ifdef KNULLI
-	// SET SRM FILE UPDATE INTERVAL
-	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SRM FILE UPDATE INTERVAL"));
-	autosaveInterval->addRange({
-		{ _("AUTO"), "" },
-		{ _("5 Sec."), "5" },
-		{ _("10 Sec."), "10" },
-		{ _("15 Sec."), "15" },
-		{ _("30 Sec."), "30" },
-		{ _("1 Min. (DEFAULT)"), "60" },
-		{ _("5 Min."), "300" },
-		{ _("10 Min."), "600" },
-		{ _("ONLY ON GAME EXIT"), "0" } },
-		SystemConf::getInstance()->get("global.srm_update_interval"));
-
-	s->addWithDescription(_("SRM FILE UPDATE INTERVAL"), _("For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X seconds/minutes."), autosaveInterval);
-	s->addSaveFunc([autosaveInterval] { SystemConf::getInstance()->set("global.srm_update_interval", autosaveInterval->getSelected()); });
+	// SET SRM FILE DUMP WHILE IN-GAME
+	auto srmDumpInGame = std::make_shared<SwitchComponent>(mWindow);
+	srmDumpInGame->setState(SystemConf::getInstance()->get("global.srm_dump_ingame") == "1");
+	s->addWithDescription(_("WRITE IN-GAME SAVES TO DISK WHILE IN GAME"), _("For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated either within 10 seconds after saved or only on game exit."), srmDumpInGame);
+	s->addSaveFunc([srmDumpInGame] { SystemConf::getInstance()->set("global.srm_dump_ingame", srmDumpInGame->getState() ? "1" : ""); });
 #endif
 
 	// INCREMENTAL SAVESTATES

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2663,7 +2663,7 @@ void GuiMenu::openGamesSettings()
 
 #ifdef KNULLI
 	// SET SRM FILE UPDATE INTERVAL
-	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SRM UPDATE INTERVAL (MINUTES)"));
+	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SRM FILE UPDATE INTERVAL (MINUTES)"));
 	autosaveInterval->addRange({
 		{ _("ONLY ON GAME EXIT (DEFAULT)"), "" },
 		{ _("1"), "1" },
@@ -2674,7 +2674,7 @@ void GuiMenu::openGamesSettings()
 		{ _("60"), "60" } },
 		SystemConf::getInstance()->get("global.autosave_interval"));
 
-	s->addWithDescription(_("SRM UPDATE INTERVAL (MINUTES)"), _("For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes."), autosaveInterval);
+	s->addWithDescription(_("SRM FILE UPDATE INTERVAL (MINUTES)"), _("For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes."), autosaveInterval);
 	s->addSaveFunc([autosaveInterval] { SystemConf::getInstance()->set("global.autosave_interval", autosaveInterval->getSelected()); });
 #endif
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2672,10 +2672,10 @@ void GuiMenu::openGamesSettings()
 		{ _("15"), "15" },
 		{ _("30"), "30" },
 		{ _("60"), "60" } },
-		SystemConf::getInstance()->get("global.autosave_interval"));
+		SystemConf::getInstance()->get("global.srm_update_interval"));
 
 	s->addWithDescription(_("SRM FILE UPDATE INTERVAL (MINUTES)"), _("For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes."), autosaveInterval);
-	s->addSaveFunc([autosaveInterval] { SystemConf::getInstance()->set("global.autosave_interval", autosaveInterval->getSelected()); });
+	s->addSaveFunc([autosaveInterval] { SystemConf::getInstance()->set("global.srm_update_interval", autosaveInterval->getSelected()); });
 #endif
 
 	// INCREMENTAL SAVESTATES

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2662,11 +2662,10 @@ void GuiMenu::openGamesSettings()
 	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getState() ? "1" : ""); });
 
 #ifdef KNULLI
-	// SET AUTOSAVE INTERVAL
-	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE INTERVAL (MINUTES)"));
+	// SET SRM FILE UPDATE INTERVAL
+	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("SRM UPDATE INTERVAL (MINUTES)"));
 	autosaveInterval->addRange({
-		{ _("AUTO"), "" },
-		{ _("NONE"), "0" },
+		{ _("ONLY ON GAME EXIT (DEFAULT)"), "" },
 		{ _("1"), "1" },
 		{ _("5"), "5" },
 		{ _("10"), "10" },
@@ -2675,7 +2674,7 @@ void GuiMenu::openGamesSettings()
 		{ _("60"), "60" } },
 		SystemConf::getInstance()->get("global.autosave_interval"));
 
-	s->addWithDescription(_("AUTO SAVE INTERVAL (MINUTES)"), _("Libretro cores will save the game state automatically every X minutes."), autosaveInterval);
+	s->addWithDescription(_("SRM UPDATE INTERVAL (MINUTES)"), _("For libretro cores, if your game allows in-game saving, the corresponding SRM file is updated every X minutes."), autosaveInterval);
 	s->addSaveFunc([autosaveInterval] { SystemConf::getInstance()->set("global.autosave_interval", autosaveInterval->getSelected()); });
 #endif
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -2661,6 +2661,24 @@ void GuiMenu::openGamesSettings()
 	s->addWithDescription(_("AUTO SAVE/LOAD"), _("Load latest savestate on game launch and savestate when exiting game."), autosave_enabled);
 	s->addSaveFunc([autosave_enabled] { SystemConf::getInstance()->set("global.autosave", autosave_enabled->getState() ? "1" : ""); });
 
+#ifdef KNULLI
+	// SET AUTOSAVE INTERVAL
+	auto autosaveInterval = std::make_shared<OptionListComponent<std::string>>(mWindow, _("AUTO SAVE INTERVAL (MINUTES)"));
+	autosaveInterval->addRange({
+		{ _("AUTO"), "" },
+		{ _("NONE"), "0" },
+		{ _("1"), "1" },
+		{ _("5"), "5" },
+		{ _("10"), "10" },
+		{ _("15"), "15" },
+		{ _("30"), "30" },
+		{ _("60"), "60" } },
+		SystemConf::getInstance()->get("global.autosave_interval"));
+
+	s->addWithDescription(_("AUTO SAVE INTERVAL (MINUTES)"), _("Libretro cores will save the game state automatically every X minutes."), autosaveInterval);
+	s->addSaveFunc([autosaveInterval] { SystemConf::getInstance()->set("global.autosave_interval", autosaveInterval->getSelected()); });
+#endif
+
 	// INCREMENTAL SAVESTATES
 	auto incrementalSaveStates = std::make_shared<OptionListComponent<std::string>>(mWindow, _("INCREMENTAL SAVESTATES"));
 	incrementalSaveStates->addRange({


### PR DESCRIPTION
Ties in with this OS update: https://github.com/knulli-cfw/knulli-linux/pull/13

Both are required to be merged for the feature to work.